### PR TITLE
Enhance support for a docmap with multiple steps

### DIFF
--- a/docmaptools/__init__.py
+++ b/docmaptools/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 
 
 LOGGER = logging.getLogger(__name__)

--- a/tests/fixtures/2021.06.02.446694.docmap.json
+++ b/tests/fixtures/2021.06.02.446694.docmap.json
@@ -1,1 +1,195 @@
-{"@context":"https://w3id.org/docmaps/context.jsonld","id":"https://sciety.org/docmaps/v1/evaluations-by/elife/10.1101/2021.06.02.446694.docmap.json","type":"docmap","created":"2022-02-15T09:50:29.018Z","updated":"2022-02-15T11:30:27.034Z","publisher":{"id":"https://elifesciences.org/","name":"eLife","logo":"https://sciety.org/static/groups/elife--b560187e-f2fb-4ff9-a861-a204f3fc0fb0.png","homepage":"https://elifesciences.org/","account":{"id":"https://sciety.org/groups/elife","service":"https://sciety.org"}},"first-step":"_:b0","steps":{"_:b0":{"assertions":[],"inputs":[{"doi":"10.1101/2021.06.02.446694","url":"https://doi.org/10.1101/2021.06.02.446694"}],"actions":[{"participants":[{"actor":{"name":"anonymous","type":"person"},"role":"peer-reviewer"}],"outputs":[{"type":"review-article","published":"2022-02-15T09:43:12.593Z","content":[{"type":"web-page","url":"https://hypothes.is/a/sQ7jVo5DEeyQwX8SmvZEzw"},{"type":"web-page","url":"https://sciety.org/articles/activity/10.1101/2021.06.02.446694#hypothesis:sQ7jVo5DEeyQwX8SmvZEzw"},{"type":"web-content","url":"https://sciety.org/evaluations/hypothesis:sQ7jVo5DEeyQwX8SmvZEzw/content"}]}]},{"participants":[{"actor":{"name":"anonymous","type":"person"},"role":"peer-reviewer"}],"outputs":[{"type":"review-article","published":"2022-02-15T09:43:13.592Z","content":[{"type":"web-page","url":"https://hypothes.is/a/saaeso5DEeyNd5_qxlJjXQ"},{"type":"web-page","url":"https://sciety.org/articles/activity/10.1101/2021.06.02.446694#hypothesis:saaeso5DEeyNd5_qxlJjXQ"},{"type":"web-content","url":"https://sciety.org/evaluations/hypothesis:saaeso5DEeyNd5_qxlJjXQ/content"}]}]},{"participants":[{"actor":{"name":"anonymous","type":"person"},"role":"peer-reviewer"}],"outputs":[{"type":"review-article","published":"2022-02-15T09:43:14.350Z","content":[{"type":"web-page","url":"https://hypothes.is/a/shmDUI5DEey0T6t05fjycg"},{"type":"web-page","url":"https://sciety.org/articles/activity/10.1101/2021.06.02.446694#hypothesis:shmDUI5DEey0T6t05fjycg"},{"type":"web-content","url":"https://sciety.org/evaluations/hypothesis:shmDUI5DEey0T6t05fjycg/content"}]}]},{"participants":[{"actor":{"name":"Ronald L Calabrese","type":"person","_relatesToOrganization":"Emory University, United States"},"role":"senior-editor"},{"actor":{"name":"Noah J Cowan","type":"person","_relatesToOrganization":"Johns Hopkins University, United States"},"role":"editor"}],"outputs":[{"type":"evaluation-summary","published":"2022-02-15T09:43:15.348Z","content":[{"type":"web-page","url":"https://hypothes.is/a/srHqyI5DEeyY91tQ-MUVKA"},{"type":"web-page","url":"https://sciety.org/articles/activity/10.1101/2021.06.02.446694#hypothesis:srHqyI5DEeyY91tQ-MUVKA"},{"type":"web-content","url":"https://sciety.org/evaluations/hypothesis:srHqyI5DEeyY91tQ-MUVKA/content"}]}]},{"participants":[{"actor":{"name":"anonymous","type":"person"},"role":"peer-reviewer"}],"outputs":[{"type":"reply","published":"2022-02-15T11:24:05.730Z","content":[{"type":"web-page","url":"https://hypothes.is/a/ySfx9I5REeyOiqtIYslcxA"},{"type":"web-page","url":"https://sciety.org/articles/activity/10.1101/2021.06.02.446694#hypothesis:ySfx9I5REeyOiqtIYslcxA"},{"type":"web-content","url":"https://sciety.org/evaluations/hypothesis:ySfx9I5REeyOiqtIYslcxA/content"}]}]}]}}}
+{
+    "@context": "https://w3id.org/docmaps/context.jsonld",
+    "id": "https://sciety.org/docmaps/v1/evaluations-by/elife/10.1101/2021.06.02.446694.docmap.json",
+    "type": "docmap",
+    "created": "2022-02-15T09:50:29.018Z",
+    "updated": "2022-02-15T11:30:27.034Z",
+    "publisher": {
+        "id": "https://elifesciences.org/",
+        "name": "eLife",
+        "logo": "https://sciety.org/static/groups/elife--b560187e-f2fb-4ff9-a861-a204f3fc0fb0.png",
+        "homepage": "https://elifesciences.org/",
+        "account": {
+            "id": "https://sciety.org/groups/elife",
+            "service": "https://sciety.org"
+        }
+    },
+    "first-step": "_:b0",
+    "steps": {
+        "_:b0": {
+            "assertions": [],
+            "inputs": [
+                {
+                    "doi": "10.1101/2021.06.02.446694",
+                    "url": "https://doi.org/10.1101/2021.06.02.446694"
+                }
+            ],
+            "actions": [
+                {
+                    "participants": [
+                        {
+                            "actor": {
+                                "name": "anonymous",
+                                "type": "person"
+                            },
+                            "role": "peer-reviewer"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "type": "review-article",
+                            "published": "2022-02-15T09:43:12.593Z",
+                            "content": [
+                                {
+                                    "type": "web-page",
+                                    "url": "https://hypothes.is/a/sQ7jVo5DEeyQwX8SmvZEzw"
+                                },
+                                {
+                                    "type": "web-page",
+                                    "url": "https://sciety.org/articles/activity/10.1101/2021.06.02.446694#hypothesis:sQ7jVo5DEeyQwX8SmvZEzw"
+                                },
+                                {
+                                    "type": "web-content",
+                                    "url": "https://sciety.org/evaluations/hypothesis:sQ7jVo5DEeyQwX8SmvZEzw/content"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "participants": [
+                        {
+                            "actor": {
+                                "name": "anonymous",
+                                "type": "person"
+                            },
+                            "role": "peer-reviewer"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "type": "review-article",
+                            "published": "2022-02-15T09:43:13.592Z",
+                            "content": [
+                                {
+                                    "type": "web-page",
+                                    "url": "https://hypothes.is/a/saaeso5DEeyNd5_qxlJjXQ"
+                                },
+                                {
+                                    "type": "web-page",
+                                    "url": "https://sciety.org/articles/activity/10.1101/2021.06.02.446694#hypothesis:saaeso5DEeyNd5_qxlJjXQ"
+                                },
+                                {
+                                    "type": "web-content",
+                                    "url": "https://sciety.org/evaluations/hypothesis:saaeso5DEeyNd5_qxlJjXQ/content"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "participants": [
+                        {
+                            "actor": {
+                                "name": "anonymous",
+                                "type": "person"
+                            },
+                            "role": "peer-reviewer"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "type": "review-article",
+                            "published": "2022-02-15T09:43:14.350Z",
+                            "content": [
+                                {
+                                    "type": "web-page",
+                                    "url": "https://hypothes.is/a/shmDUI5DEey0T6t05fjycg"
+                                },
+                                {
+                                    "type": "web-page",
+                                    "url": "https://sciety.org/articles/activity/10.1101/2021.06.02.446694#hypothesis:shmDUI5DEey0T6t05fjycg"
+                                },
+                                {
+                                    "type": "web-content",
+                                    "url": "https://sciety.org/evaluations/hypothesis:shmDUI5DEey0T6t05fjycg/content"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "participants": [
+                        {
+                            "actor": {
+                                "name": "Ronald L Calabrese",
+                                "type": "person",
+                                "_relatesToOrganization": "Emory University, United States"
+                            },
+                            "role": "senior-editor"
+                        },
+                        {
+                            "actor": {
+                                "name": "Noah J Cowan",
+                                "type": "person",
+                                "_relatesToOrganization": "Johns Hopkins University, United States"
+                            },
+                            "role": "editor"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "type": "evaluation-summary",
+                            "published": "2022-02-15T09:43:15.348Z",
+                            "content": [
+                                {
+                                    "type": "web-page",
+                                    "url": "https://hypothes.is/a/srHqyI5DEeyY91tQ-MUVKA"
+                                },
+                                {
+                                    "type": "web-page",
+                                    "url": "https://sciety.org/articles/activity/10.1101/2021.06.02.446694#hypothesis:srHqyI5DEeyY91tQ-MUVKA"
+                                },
+                                {
+                                    "type": "web-content",
+                                    "url": "https://sciety.org/evaluations/hypothesis:srHqyI5DEeyY91tQ-MUVKA/content"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "participants": [
+                        {
+                            "actor": {
+                                "name": "anonymous",
+                                "type": "person"
+                            },
+                            "role": "peer-reviewer"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "type": "reply",
+                            "published": "2022-02-15T11:24:05.730Z",
+                            "content": [
+                                {
+                                    "type": "web-page",
+                                    "url": "https://hypothes.is/a/ySfx9I5REeyOiqtIYslcxA"
+                                },
+                                {
+                                    "type": "web-page",
+                                    "url": "https://sciety.org/articles/activity/10.1101/2021.06.02.446694#hypothesis:ySfx9I5REeyOiqtIYslcxA"
+                                },
+                                {
+                                    "type": "web-content",
+                                    "url": "https://sciety.org/evaluations/hypothesis:ySfx9I5REeyOiqtIYslcxA/content"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/tests/fixtures/2022.10.17.512253.docmap.json
+++ b/tests/fixtures/2022.10.17.512253.docmap.json
@@ -1,0 +1,249 @@
+{
+    "@context": "https://w3id.org/docmaps/context.jsonld",
+    "type": "docmap",
+    "id": "https://data-hub-api.elifesciences.org/enhanced-preprints/docmaps/v1/get-by-doi?preprint_doi=10.1101%2F2022.10.17.512253",
+    "created": "2022-11-08T07:01:52+00:00",
+    "updated": "2022-11-08T07:01:52+00:00",
+    "publisher": {
+        "account": {
+            "id": "https://sciety.org/groups/elife",
+            "service": "https://sciety.org"
+        },
+        "homepage": "https://elifesciences.org/",
+        "id": "https://elifesciences.org/",
+        "logo": "https://sciety.org/static/groups/elife--b560187e-f2fb-4ff9-a861-a204f3fc0fb0.png",
+        "name": "eLife"
+    },
+    "first-step": "_:b0",
+    "steps": {
+        "_:b0": {
+            "actions": [
+                {
+                    "participants": [],
+                    "outputs": [
+                        {
+                            "type": "preprint",
+                            "doi": "10.1101/2022.10.17.512253",
+                            "url": "https://www.biorxiv.org/content/10.1101/2022.10.17.512253v1",
+                            "published": "2022-10-17",
+                            "versionIdentifier": "1",
+                            "_tdmPath": "s3://transfers-elife/biorxiv_Current_Content/October_2022/18_Oct_22_Batch_1408/a6575018-6cfe-1014-94b3-ca3c122c1e09.meca"
+                        }
+                    ]
+                }
+            ],
+            "assertions": [
+                {
+                    "item": {
+                        "type": "preprint",
+                        "doi": "10.1101/2022.10.17.512253",
+                        "versionIdentifier": "1"
+                    },
+                    "status": "manuscript-published"
+                }
+            ],
+            "inputs": [],
+            "next-step": "_:b1"
+        },
+        "_:b1": {
+            "actions": [
+                {
+                    "participants": [],
+                    "outputs": [
+                        {
+                            "identifier": "84364",
+                            "versionIdentifier": "",
+                            "type": "preprint",
+                            "doi": "10.7554/eLife.84364"
+                        }
+                    ]
+                }
+            ],
+            "assertions": [
+                {
+                    "item": {
+                        "type": "preprint",
+                        "doi": "10.1101/2022.10.17.512253",
+                        "versionIdentifier": "1"
+                    },
+                    "status": "under-review",
+                    "happened": "2022-11-08T07:01:52+00:00"
+                },
+                {
+                    "item": {
+                        "type": "preprint",
+                        "doi": "10.7554/eLife.84364",
+                        "versionIdentifier": ""
+                    },
+                    "status": "draft"
+                }
+            ],
+            "inputs": [
+                {
+                    "type": "preprint",
+                    "doi": "10.1101/2022.10.17.512253",
+                    "url": "https://www.biorxiv.org/content/10.1101/2022.10.17.512253v1",
+                    "versionIdentifier": "1"
+                }
+            ],
+            "next-step": "_:b2",
+            "previous-step": "_:b0"
+        },
+        "_:b2": {
+            "actions": [
+                {
+                    "participants": [
+                        {
+                            "actor": {
+                                "name": "anonymous",
+                                "type": "person"
+                            },
+                            "role": "peer-reviewer"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "type": "review-article",
+                            "published": "2023-02-09T16:36:07.240248+00:00",
+                            "content": [
+                                {
+                                    "type": "web-page",
+                                    "url": "https://hypothes.is/a/2jRPwqiXEe2WiaPpkX9z0A"
+                                },
+                                {
+                                    "type": "web-page",
+                                    "url": "https://sciety.org/articles/activity/10.1101/2022.10.17.512253#hypothesis:2jRPwqiXEe2WiaPpkX9z0A"
+                                },
+                                {
+                                    "type": "web-page",
+                                    "url": "https://sciety.org/evaluations/hypothesis:2jRPwqiXEe2WiaPpkX9z0A/content"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "participants": [
+                        {
+                            "actor": {
+                                "name": "anonymous",
+                                "type": "person"
+                            },
+                            "role": "peer-reviewer"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "type": "review-article",
+                            "published": "2023-02-09T16:36:08.237709+00:00",
+                            "content": [
+                                {
+                                    "type": "web-page",
+                                    "url": "https://hypothes.is/a/2ssR5qiXEe2eBA-GlPB-OA"
+                                },
+                                {
+                                    "type": "web-page",
+                                    "url": "https://sciety.org/articles/activity/10.1101/2022.10.17.512253#hypothesis:2ssR5qiXEe2eBA-GlPB-OA"
+                                },
+                                {
+                                    "type": "web-page",
+                                    "url": "https://sciety.org/evaluations/hypothesis:2ssR5qiXEe2eBA-GlPB-OA/content"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "participants": [
+                        {
+                            "actor": {
+                                "name": "anonymous",
+                                "type": "person"
+                            },
+                            "role": "peer-reviewer"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "type": "review-article",
+                            "published": "2023-02-09T16:36:09.046089+00:00",
+                            "content": [
+                                {
+                                    "type": "web-page",
+                                    "url": "https://hypothes.is/a/20aozqiXEe2cFHOdrUiwoQ"
+                                },
+                                {
+                                    "type": "web-page",
+                                    "url": "https://sciety.org/articles/activity/10.1101/2022.10.17.512253#hypothesis:20aozqiXEe2cFHOdrUiwoQ"
+                                },
+                                {
+                                    "type": "web-page",
+                                    "url": "https://sciety.org/evaluations/hypothesis:20aozqiXEe2cFHOdrUiwoQ/content"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "participants": [
+                        {
+                            "actor": {
+                                "name": "Michael Eisen",
+                                "type": "person",
+                                "_relatesToOrganization": "University of California, Berkeley, United States of America"
+                            },
+                            "role": "editor"
+                        },
+                        {
+                            "actor": {
+                                "name": "Michael Eisen",
+                                "type": "person",
+                                "_relatesToOrganization": "University of California, Berkeley, United States of America"
+                            },
+                            "role": "senior-editor"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "type": "evaluation-summary",
+                            "published": "2023-02-09T16:36:09.857359+00:00",
+                            "content": [
+                                {
+                                    "type": "web-page",
+                                    "url": "https://hypothes.is/a/28TBAKiXEe2gLa-4_Zmg3Q"
+                                },
+                                {
+                                    "type": "web-page",
+                                    "url": "https://sciety.org/articles/activity/10.1101/2022.10.17.512253#hypothesis:28TBAKiXEe2gLa-4_Zmg3Q"
+                                },
+                                {
+                                    "type": "web-page",
+                                    "url": "https://sciety.org/evaluations/hypothesis:28TBAKiXEe2gLa-4_Zmg3Q/content"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "assertions": [
+                {
+                    "item": {
+                        "type": "preprint",
+                        "doi": "10.1101/2022.10.17.512253",
+                        "versionIdentifier": "1"
+                    },
+                    "status": "peer-reviewed"
+                }
+            ],
+            "inputs": [
+                {
+                    "type": "preprint",
+                    "doi": "10.1101/2022.10.17.512253",
+                    "url": "https://www.biorxiv.org/content/10.1101/2022.10.17.512253v1",
+                    "versionIdentifier": "1"
+                }
+            ],
+            "previous-step": "_:b1"
+        }
+    }
+}


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/8045

Another docmap format which contains multiple steps is supported, as well as the previous single-step docmap. This is still a work in progress and as new examples are available this library will aim to support each type.