### PR TITLE
Alter preprint history on newer sample docmap.

### DIFF
--- a/docmaptools/__init__.py
+++ b/docmaptools/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-__version__ = "0.7.0"
+__version__ = "0.8.0"
 
 
 LOGGER = logging.getLogger(__name__)

--- a/docmaptools/parse.py
+++ b/docmaptools/parse.py
@@ -85,6 +85,15 @@ def docmap_preprint_history(d_json):
     step_json = docmap_first_step(d_json)
     preprint_events = []
     found_first_preprint = False
+    # add preprint first
+    if docmap_preprint(d_json):
+        # collect the preprint details
+        event_details = preprint_event_output(
+            docmap_preprint(d_json), step_json, found_first_preprint
+        )
+        # append the events details to the matser list
+        preprint_events.append(event_details)
+        found_first_preprint = True
     while step_json:
         for action_json in step_actions(step_json):
             for output_json in action_outputs(action_json):
@@ -97,7 +106,8 @@ def docmap_preprint_history(d_json):
                         output_json, step_json, found_first_preprint
                     )
                     # append the events details to the matser list
-                    preprint_events.append(event_details)
+                    if event_details.get("date"):
+                        preprint_events.append(event_details)
 
                     # will have found the preprint from the first matched step
                     found_first_preprint = True
@@ -133,7 +143,7 @@ def preprint_happened_date(step_json):
     if not step_json or not step_json.get("assertions"):
         return None
     for assertion in step_json.get("assertions", []):
-        if assertion.get("happened"):
+        if assertion.get("status") == "manuscript-published" and assertion.get("happened"):
             return assertion.get("happened")
     return None
 
@@ -147,7 +157,7 @@ def preprint_alternate_date(step_json):
         for output_json in action_outputs(action_json):
             if (
                 output_json.get("published")
-                and output_json.get("type") == "evaluation-summary"
+                and output_json.get("type") == "preprint"
             ):
                 return output_json.get("published")
     return None

--- a/tests/fixtures/sample_docmap_for_86628.json
+++ b/tests/fixtures/sample_docmap_for_86628.json
@@ -1,0 +1,424 @@
+{
+  "@context": "https://w3id.org/docmaps/context.jsonld",
+  "type": "docmap",
+  "id": "https://data-hub-api.elifesciences.org/enhanced-preprints/docmaps/v1/by-publisher/elife/get-by-manuscript-id?manuscript_id=86628",
+  "created": "2023-02-02T07:04:33+00:00",
+  "updated": "2023-02-02T07:04:33+00:00",
+  "publisher": "{\"account\":{\"id\":\"https://sciety.org/groups/elife\",\"service\":\"https://sciety.org\"},\"homepage\":\"https://elifesciences.org/\",\"id\":\"https://elifesciences.org/\",\"logo\":\"https://sciety.org/static/groups/elife--b560187e-f2fb-4ff9-a861-a204f3fc0fb0.png\",\"name\":\"eLife\"}",
+  "first-step": "_:b0",
+  "steps": {
+    "_:b0": {
+      "actions": [
+        {
+          "participants": [],
+          "outputs": [
+            {
+              "type": "preprint",
+              "identifier": "86628",
+              "doi": "10.7554/eLife.86628.1",
+              "versionIdentifier": "1",
+              "license": "http://creativecommons.org/licenses/by/4.0/"
+            }
+          ]
+        }
+      ],
+      "assertions": [
+        {
+          "item": {
+            "type": "preprint",
+            "doi": "10.1101/2023.02.14.528498",
+            "versionIdentifier": "2"
+          },
+          "status": "under-review",
+          "happened": "2023-02-14T15:44:21+00:00"
+        },
+        {
+          "item": {
+            "type": "preprint",
+            "doi": "10.7554/eLife.86628.1",
+            "versionIdentifier": "1"
+          },
+          "status": "draft"
+        }
+      ],
+      "inputs": [
+        {
+          "type": "preprint",
+          "doi": "10.1101/2023.02.14.528498",
+          "url": "https://www.biorxiv.org/content/10.1101/2023.02.14.528498v2",
+          "versionIdentifier": "2",
+          "published": "2023-02-21",
+          "_tdmPath": "s3://transfers-elife/biorxiv_Current_Content/February_2023/22_Feb_23_Batch_1531/c27a22b7-6c43-1014-aa80-efc7cf011f1d.meca"
+        }
+      ],
+      "next-step": "_:b1"
+    },
+    "_:b1": {
+      "actions": [
+        {
+          "participants": [
+            {
+              "actor": {
+                "name": "anonymous",
+                "type": "person"
+              },
+              "role": "peer-reviewer"
+            }
+          ],
+          "outputs": [
+            {
+              "type": "review-article",
+              "published": "2023-04-06T11:44:05.502835+00:00",
+              "doi": "10.7554/eLife.86628.1.sa1",
+              "license": "http://creativecommons.org/licenses/by/4.0/",
+              "url": "https://doi.org/10.7554/eLife.86628.1.sa1",
+              "content": [
+                {
+                  "type": "web-page",
+                  "url": "https://hypothes.is/a/VZA2tNRwEe2Gn6fVyZDsZw"
+                },
+                {
+                  "type": "web-page",
+                  "url": "https://sciety.org/articles/activity/10.1101/2023.02.14.528498#hypothesis:VZA2tNRwEe2Gn6fVyZDsZw"
+                },
+                {
+                  "type": "web-page",
+                  "url": "https://sciety.org/evaluations/hypothesis:VZA2tNRwEe2Gn6fVyZDsZw/content"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "participants": [
+            {
+              "actor": {
+                "name": "Gary Yellen",
+                "type": "person",
+                "_relatesToOrganization": "Harvard Medical School, United States of America"
+              },
+              "role": "editor"
+            },
+            {
+              "actor": {
+                "name": "David James",
+                "type": "person",
+                "_relatesToOrganization": "University of Sydney, Australia"
+              },
+              "role": "senior-editor"
+            }
+          ],
+          "outputs": [
+            {
+              "type": "evaluation-summary",
+              "published": "2023-04-06T11:44:15.700445+00:00",
+              "doi": "10.7554/eLife.86628.1.sa2",
+              "license": "http://creativecommons.org/licenses/by/4.0/",
+              "url": "https://doi.org/10.7554/eLife.86628.1.sa2",
+              "content": [
+                {
+                  "type": "web-page",
+                  "url": "https://hypothes.is/a/W6Lk6NRwEe27ZnsdX_tiKQ"
+                },
+                {
+                  "type": "web-page",
+                  "url": "https://sciety.org/articles/activity/10.1101/2023.02.14.528498#hypothesis:W6Lk6NRwEe27ZnsdX_tiKQ"
+                },
+                {
+                  "type": "web-page",
+                  "url": "https://sciety.org/evaluations/hypothesis:W6Lk6NRwEe27ZnsdX_tiKQ/content"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "assertions": [
+        {
+          "item": {
+            "type": "preprint",
+            "doi": "10.1101/2023.02.14.528498",
+            "versionIdentifier": "2"
+          },
+          "status": "peer-reviewed"
+        }
+      ],
+      "inputs": [
+        {
+          "type": "preprint",
+          "doi": "10.1101/2023.02.14.528498",
+          "url": "https://www.biorxiv.org/content/10.1101/2023.02.14.528498v2",
+          "versionIdentifier": "2"
+        }
+      ],
+      "next-step": "_:b2",
+      "previous-step": "_:b0"
+    },
+    "_:b2": {
+      "actions": [
+        {
+          "participants": [],
+          "outputs": [
+            {
+              "type": "preprint",
+              "published": "TBC",
+              "identifier": "86628",
+              "doi": "10.7554/eLife.86628.1",
+              "versionIdentifier": "1",
+              "license": "http://creativecommons.org/licenses/by/4.0/"
+            }
+          ]
+        }
+      ],
+      "assertions": [
+        {
+          "item": {
+            "type": "preprint",
+            "doi": "10.7554/eLife.86628.1",
+            "versionIdentifier": "1"
+          },
+          "status": "manuscript-published"
+        }
+      ],
+      "inputs": [
+        {
+          "type": "preprint",
+          "doi": "10.1101/2023.02.14.528498",
+          "url": "https://www.biorxiv.org/content/10.1101/2023.02.14.528498v2",
+          "versionIdentifier": "2"
+        },
+        {
+          "type": "review-article",
+          "doi": "10.7554/eLife.86628.1.sa1"
+        },
+        {
+          "type": "evaluation-summary",
+          "doi": "10.7554/eLife.86628.1.sa2"
+        }],
+      "next-step": "_:b3",
+      "previous-step": "_:b1"
+    },
+    "_:b3": {
+      "actions": [
+        {
+          "participants": [],
+          "outputs": [
+            {
+              "type": "preprint",
+              "identifier": "86628",
+              "doi": "10.7554/eLife.86628.2",
+              "versionIdentifier": "2",
+              "license": "http://creativecommons.org/licenses/by/4.0/"
+            }
+          ]
+        }
+      ],
+      "assertions": [
+        {
+          "item": {
+            "type": "preprint",
+            "doi": "10.1101/2023.02.14.528498",
+            "versionIdentifier": "3"
+          },
+          "status": "under-review",
+          "happened": "2023-04-11T13:15:26+00:00"
+        },
+        {
+          "item": {
+            "type": "preprint",
+            "doi": "10.7554/eLife.86628.2",
+            "versionIdentifier": "2"
+          },
+          "status": "draft"
+        }
+      ],
+      "inputs": [
+        {
+          "type": "preprint",
+          "doi": "10.1101/2023.02.14.528498",
+          "url": "https://www.biorxiv.org/content/10.1101/2023.02.14.528498v3",
+          "versionIdentifier": "3",
+          "published": "2023-04-24",
+          "_tdmPath": ""
+        }
+      ],
+      "next-step": "_:b4",
+      "previous-step": "_:b2"
+    },
+    "_:b4": {
+      "actions": [
+        {
+          "participants": [],
+          "outputs": [
+            {
+              "type": "reply",
+              "published": "2023-05-11T11:34:27.242112+00:00",
+              "doi": "10.7554/eLife.86628.2.sa1",
+              "license": "http://creativecommons.org/licenses/by/4.0/",
+              "url": "https://doi.org/10.7554/eLife.86628.2.sa1",
+              "content": [
+                {
+                  "type": "web-page",
+                  "url": "https://hypothes.is/a/yVioUu_vEe2vQTPxYtnZSw"
+                },
+                {
+                  "type": "web-page",
+                  "url": "https://sciety.org/articles/activity/10.1101/2023.02.14.528498#hypothesis:yVioUu_vEe2vQTPxYtnZSw"
+                },
+                {
+                  "type": "web-page",
+                  "url": "https://sciety.org/evaluations/hypothesis:yVioUu_vEe2vQTPxYtnZSw/content"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "participants": [
+            {
+              "actor": {
+                "name": "anonymous",
+                "type": "person"
+              },
+              "role": "peer-reviewer"
+            }
+          ],
+          "outputs": [
+            {
+              "type": "review-article",
+              "published": "2023-05-11T11:34:28.135284+00:00",
+              "doi": "10.7554/eLife.86628.2.sa2",
+              "license": "http://creativecommons.org/licenses/by/4.0/",
+              "url": "https://doi.org/10.7554/eLife.86628.2.sa2",
+              "content": [
+                {
+                  "type": "web-page",
+                  "url": "https://hypothes.is/a/yeEcZO_vEe2Dxo8DxUJqTw"
+                },
+                {
+                  "type": "web-page",
+                  "url": "https://sciety.org/articles/activity/10.1101/2023.02.14.528498#hypothesis:yeEcZO_vEe2Dxo8DxUJqTw"
+                },
+                {
+                  "type": "web-page",
+                  "url": "https://sciety.org/evaluations/hypothesis:yeEcZO_vEe2Dxo8DxUJqTw/content"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "participants": [
+            {
+              "actor": {
+                "name": "Gary Yellen",
+                "type": "person",
+                "_relatesToOrganization": "Harvard Medical School, United States of America"
+              },
+              "role": "editor"
+            },
+            {
+              "actor": {
+                "name": "David James",
+                "type": "person",
+                "_relatesToOrganization": "University of Sydney, Australia"
+              },
+              "role": "senior-editor"
+            }
+          ],
+          "outputs": [
+            {
+              "type": "evaluation-summary",
+              "published": "2023-05-11T11:34:28.903631+00:00",
+              "doi": "10.7554/eLife.86628.2.sa3",
+              "license": "http://creativecommons.org/licenses/by/4.0/",
+              "url": "https://doi.org/10.7554/eLife.86628.2.sa3",
+              "content": [
+                {
+                  "type": "web-page",
+                  "url": "https://hypothes.is/a/ylaROO_vEe2VSj_o0Xi_gA"
+                },
+                {
+                  "type": "web-page",
+                  "url": "https://sciety.org/articles/activity/10.1101/2023.02.14.528498#hypothesis:ylaROO_vEe2VSj_o0Xi_gA"
+                },
+                {
+                  "type": "web-page",
+                  "url": "https://sciety.org/evaluations/hypothesis:ylaROO_vEe2VSj_o0Xi_gA/content"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "assertions": [
+        {
+          "item": {
+            "type": "preprint",
+            "doi": "10.1101/2023.02.14.528498",
+            "versionIdentifier": "3"
+          },
+          "status": "revised"
+        }
+      ],
+      "inputs": [
+        {
+          "type": "preprint",
+          "doi": "10.1101/2023.02.14.528498",
+          "url": "https://www.biorxiv.org/content/10.1101/2023.02.14.528498v3",
+          "versionIdentifier": "3"
+        }
+      ],
+      "next-step": "_:b5",
+      "previous-step": "_:b3"
+    },
+    "_:b5": {
+      "actions": [
+        {
+          "participants": [],
+          "outputs": [
+            {
+              "type": "preprint",
+              "published": "TBC",
+              "identifier": "86628",
+              "doi": "10.7554/eLife.86628.2",
+              "versionIdentifier": "2",
+              "license": "http://creativecommons.org/licenses/by/4.0/"
+            }
+          ]
+        }
+      ],
+      "assertions": [
+        {
+          "item": {
+            "type": "preprint",
+            "doi": "10.7554/eLife.86628.2",
+            "versionIdentifier": "2"
+          },
+          "status": "manuscript-published"
+        }
+      ],
+      "inputs": [
+        {
+          "type": "preprint",
+          "doi": "10.1101/2023.02.14.528498",
+          "url": "https://www.biorxiv.org/content/10.1101/2023.02.14.528498v3",
+          "versionIdentifier": "3"
+        },
+        {
+          "type": "reply",
+          "doi": "10.7554/eLife.86628.2.sa1"
+        },
+        {
+          "type": "review-article",
+          "doi": "10.7554/eLife.86628.2.sa2"
+        },
+        {
+          "type": "evaluation-summary",
+          "doi": "10.7554/eLife.86628.2.sa3"
+        }
+      ],
+      "previous-step": "_:b4"
+    }
+  }
+}


### PR DESCRIPTION
Parse the preprint history from a newer docmap sample file based on article `86628`, which still includes some `TBC` dates. Older docmap samples return fewer preprint history events since they are missing the `published` date in the `output`, as is now expected to consider a preprint as a published event.