### PR TITLE
Wrap list-item content in a p tag.

### DIFF
--- a/docmaptools/__init__.py
+++ b/docmaptools/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-__version__ = "0.8.0"
+__version__ = "0.9.0"
 
 
 LOGGER = logging.getLogger(__name__)

--- a/docmaptools/convert.py
+++ b/docmaptools/convert.py
@@ -76,6 +76,21 @@ def replace_tags(root):
             del elem.attrib["title"]
     for elem in root.findall(".//li"):
         elem.tag = "list-item"
+        # copy the contnet to a p tag
+        p_tag = Element("p")
+        p_tag.text = elem.text
+        p_tag.tail = elem.tail
+        # remove old tag content
+        elem.text = None
+        elem.tail = None
+        # copy the tags to the p tag
+        for tag_index, child_tag in enumerate(elem.iterfind("*")):
+            # insert into the new tag
+            p_tag.insert(tag_index, child_tag)
+            # remove old tag
+            elem.remove(child_tag)
+        # insert the p tag
+        elem.insert(0, p_tag)
     for elem in root.findall(".//ol"):
         elem.tag = "list"
         elem.set("list-type", "order")

--- a/tests/fixtures/sample_page.xml
+++ b/tests/fixtures/sample_page.xml
@@ -4,11 +4,11 @@
 <p>This paper provides experimental and modeling analysis of the inter-brain coupling of socially interacting bats, and reports that coordinated brain activity evolves at a slower time scale than the activity describing the differences. Specifically, the paper finds that there is an attracting submanifold corresponding to the mean (or "common mode") of neural activity, and that the dynamics in the orthogonal eigenmode, corresponding to the difference in brain activity, decays rapidly. These rapid decays in the difference mode are referred to as "catch up" activity.</p>
 <p>There are two main findings:</p>
 <list list-type="order">
-<list-item>Neural activity (especially higher frequency LFP activity in the 30-150Hz range) is modulated by social context. Specifically, the ratio of the averaged, moment-to-moment MEAN:DIFF ratio is much higher when the bats are in a single chamber, clearly indicating that the animals are coordinating their neural activity. This change also seems to hold -- although not as striking -- in lower-frequency LFP and spiking activity.</list-item>
-</list>
+<list-item><p>Neural activity (especially higher frequency LFP activity in the 30-150Hz range) is modulated by social context. Specifically, the ratio of the averaged, moment-to-moment MEAN:DIFF ratio is much higher when the bats are in a single chamber, clearly indicating that the animals are coordinating their neural activity. This change also seems to hold -- although not as striking -- in lower-frequency LFP and spiking activity.</p>
+</list-item></list>
 <list start="2" list-type="order">
-<list-item>The time scales of the mean vs. difference dynamics are segregated: the "difference dynamics" evolve at a faster time scale than "similarity dynamics", seems to be well supported.</list-item>
-</list>
+<list-item><p>The time scales of the mean vs. difference dynamics are segregated: the "difference dynamics" evolve at a faster time scale than "similarity dynamics", seems to be well supported.</p>
+</list-item></list>
 <p>The basic finding is presented in Figure 1. The rest of the paper is focused on a modeling study to garner further insight into the dynamics.</p>
 <p>Weaknesses:</p>
 <p>This is an entirely phenomenological paper, and while it claims to garner "mechanistic insight", it is unclear what that means.</p>

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -23,7 +23,7 @@ class TestConvertHtml(unittest.TestCase):
         string = (
             b"<p>"
             b"<em><strong>Test</strong></em>"
-            b"<ul><li><em>dot</em></li></ul>"
+            b"<ul><li>Text <em><strong>dot</strong></em> tail</li></ul>"
             b"</p>"
         )
         expected = (
@@ -31,7 +31,11 @@ class TestConvertHtml(unittest.TestCase):
             b"<body>"
             b"<p>"
             b"<italic><bold>Test</bold></italic>"
-            b'<list list-type="bullet"><list-item><italic>dot</italic></list-item></list>'
+            b'<list list-type="bullet">'
+            b"<list-item>"
+            b"<p>Text <italic><bold>dot</bold></italic> tail</p>"
+            b"</list-item>"
+            b"</list>"
             b"</p></body>"
             b"</root>"
         )
@@ -193,7 +197,7 @@ class TestReplaceTags(unittest.TestCase):
 
     def test_replace_tags_li(self):
         xml_string = b"<root><li/></root>"
-        expected = b"<root><list-item /></root>"
+        expected = b"<root><list-item><p /></list-item></root>"
         self.assertEqual(invoke_module_function(xml_string, "replace_tags"), expected)
 
     def test_replace_tags_ol(self):


### PR DESCRIPTION
In `replace_tags()`, when converting an HTML `<li>` tag to XML, what is inside it wrap with a `<p>` tag.

Re issue https://github.com/elifesciences/issues/issues/8310