### PR TITLE
Convert HTML br to break, XML break tags to p.

### DIFF
--- a/docmaptools/__init__.py
+++ b/docmaptools/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-__version__ = "0.10.0"
+__version__ = "0.11.0"
 
 
 LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION
When converting HTML to XML, convert `<br>` tags into `<break>` tags.

Further, convert some`<break/>` tags into `<p>` tags in the XML.

Re issue https://github.com/elifesciences/issues/issues/8347