### PR TITLE
Improve break_tags() for a disp-quote example.

### DIFF
--- a/docmaptools/__init__.py
+++ b/docmaptools/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-__version__ = "0.11.0"
+__version__ = "0.11.1"
 
 
 LOGGER = logging.getLogger(__name__)

--- a/docmaptools/convert.py
+++ b/docmaptools/convert.py
@@ -127,29 +127,33 @@ def blockquote_tags(root):
 
 def break_tags(root):
     "convert break tag to p tag"
-    # detect break tag as a direct descendant of a p tag
-    for p_index, elem in enumerate(root.iterfind("p")):
-        # find break tags
-        break_tag_indexes = []
-        for tag_index, child_tag in enumerate(elem.iterfind("*")):
-            if child_tag.tag == "break":
-                break_tag_indexes.append(tag_index)
+    # find p tag parent to later insert the new p tag
+    for p_tag_parent in root.iterfind(".//p/.."):
+        # detect break tag as a direct descendant of a p tag
+        for p_index, elem in enumerate(p_tag_parent.iterfind("p")):
+            # find break tags
+            break_tag_indexes = []
+            for tag_index, child_tag in enumerate(elem.iterfind("*")):
+                if child_tag.tag == "break":
+                    break_tag_indexes.append(tag_index)
 
-        # process the list in reverse order so the indexes are reliable
-        break_tag_indexes.reverse()
-        for break_index in break_tag_indexes:
-            p_tag = Element("p")
-            # note: does not retain any text wrapped by a break tag
-            p_tag.text = elem[break_index].tail
+            # process the list in reverse order so the indexes are reliable
+            break_tag_indexes.reverse()
+            for break_index in break_tag_indexes:
+                p_tag = Element("p")
+                # note: does not retain any text wrapped by a break tag
+                p_tag.text = elem[break_index].tail
 
-            for after_break_tag_index, after_break_tag in enumerate(elem.iterfind("*")):
-                if after_break_tag_index > break_index:
-                    p_tag.append(after_break_tag)
-                    elem.remove(after_break_tag)
+                for after_break_tag_index, after_break_tag in enumerate(
+                    elem.iterfind("*")
+                ):
+                    if after_break_tag_index > break_index:
+                        p_tag.append(after_break_tag)
+                        elem.remove(after_break_tag)
 
-            elem.remove(elem[break_index])
+                elem.remove(elem[break_index])
 
-            root.insert(p_index + 1, p_tag)
+                p_tag_parent.insert(p_index + 1, p_tag)
 
 
 def article_title_tag(root):

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -105,6 +105,34 @@ class TestBreakTags(unittest.TestCase):
         convert.break_tags(root)
         self.assertEqual(ElementTree.tostring(root), expected)
 
+    def test_nested_p_tag(self):
+        "example with a body tag and p tag inside a disp-quote tag"
+        xml_string = (
+            "<root>"
+            "<body>"
+            "<p>First.</p>"
+            '<disp-quote content-type="editor-comment">'
+            "<p>Quotation.<break/>"
+            "Another quotation</p>"
+            "</disp-quote>"
+            "</body>"
+            "</root>"
+        )
+        expected = (
+            b"<root>"
+            b"<body>"
+            b"<p>First.</p>"
+            b'<disp-quote content-type="editor-comment">'
+            b"<p>Quotation.</p>"
+            b"<p>Another quotation</p>"
+            b"</disp-quote>"
+            b"</body>"
+            b"</root>"
+        )
+        root = ElementTree.fromstring(xml_string)
+        convert.break_tags(root)
+        self.assertEqual(ElementTree.tostring(root), expected)
+
     def test_unmatched_close_tag(self):
         "example where the break tag separates an inline formatting open and close tag"
         xml_string = "<root>" "<p>This <italic>is<break/></italic>ugly.</p>" "</root>"


### PR DESCRIPTION
Improvement to code merged in PR https://github.com/elifesciences/docmap-tools/pull/24, in a real example the `<break />` tags inside a `<disp-quote>` tag were not converted, and these can be converted.

Re issue https://github.com/elifesciences/issues/issues/8347