### PR TITLE
Get under-review preprint assertion date; refactor

### DIFF
--- a/docmaptools/__init__.py
+++ b/docmaptools/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-__version__ = "0.11.1"
+__version__ = "0.12.0"
 
 
 LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION
From the assertions of type preprint, get the happened date for when the assertion is type `under-review`. Includes some refactoring related to preprint assertions functions.

Re issue https://github.com/elifesciences/issues/issues/7721