### PR TITLE
Update docmap test fixtures to fresher data.

### DIFF
--- a/tests/fixtures/sample_docmap_for_85111.json
+++ b/tests/fixtures/sample_docmap_for_85111.json
@@ -1,438 +1,541 @@
 {
   "@context": "https://w3id.org/docmaps/context.jsonld",
   "type": "docmap",
-  "id": "https://data-hub-api.elifesciences.org/enhanced-preprints/docmaps/v1/by-publisher/elife/get-by-manuscript-id?manuscript_id=85111",
+  "id": "https://data-hub-api.elifesciences.org/enhanced-preprints/docmaps/v2/by-publisher/elife/get-by-manuscript-id?manuscript_id=85111",
   "created": "2022-11-28T11:30:05+00:00",
   "updated": "2022-11-28T11:30:05+00:00",
-  "publisher": {
-    "account": {
-      "id": "https://sciety.org/groups/elife",
-      "service": "https://sciety.org"
-    },
-    "homepage": "https://elifesciences.org/",
-    "id": "https://elifesciences.org/",
-    "logo": "https://sciety.org/static/groups/elife--b560187e-f2fb-4ff9-a861-a204f3fc0fb0.png",
-    "name": "eLife"
-  },
+  "publisher": "{\"account\":{\"id\":\"https://sciety.org/groups/elife\",\"service\":\"https://sciety.org\"},\"homepage\":\"https://elifesciences.org/\",\"id\":\"https://elifesciences.org/\",\"logo\":\"https://sciety.org/static/groups/elife--b560187e-f2fb-4ff9-a861-a204f3fc0fb0.png\",\"name\":\"eLife\"}",
   "first-step": "_:b0",
   "steps": {
-    "_:b0": {
-      "actions": [
-        {
-          "participants": [],
-          "outputs": [
-            {
-              "type": "preprint",
-              "doi": "10.1101/2022.11.08.515698",
-              "url": "https://www.biorxiv.org/content/10.1101/2022.11.08.515698v2",
-              "published": "2022-11-22",
-              "versionIdentifier": "2",
-              "_tdmPath": "s3://transfers-elife/biorxiv_Current_Content/November_2022/23_Nov_22_Batch_1444/b0f4d90b-6c92-1014-9a2e-aae015926ab4.meca"
-            }
-          ]
-        }
-      ],
-      "assertions": [
-        {
-          "item": {
-            "type": "preprint",
-            "doi": "10.1101/2022.11.08.515698",
-            "versionIdentifier": "2"
-          },
-          "status": "manuscript-published"
-        }
-      ],
-      "inputs": [],
-      "next-step": "_:b1"
-    },
-    "_:b1": {
-      "actions": [
-        {
-          "participants": [],
-          "outputs": [
-            {
-              "identifier": "85111",
-              "versionIdentifier": "1",
-              "type": "preprint",
-              "doi": "10.7554/eLife.85111.1"
-            }
-          ]
-        }
-      ],
-      "assertions": [
-        {
-          "item": {
-            "type": "preprint",
-            "doi": "10.1101/2022.11.08.515698",
-            "versionIdentifier": "2"
-          },
-          "status": "under-review",
-          "happened": "2022-11-28T11:30:05+00:00"
-        },
-        {
-          "item": {
-            "type": "preprint",
-            "doi": "10.7554/eLife.85111.1",
-            "versionIdentifier": "1"
-          },
-          "status": "draft"
-        }
-      ],
-      "inputs": [
-        {
-          "type": "preprint",
-          "doi": "10.1101/2022.11.08.515698",
-          "url": "https://www.biorxiv.org/content/10.1101/2022.11.08.515698v2",
-          "versionIdentifier": "2"
-        }
-      ],
-      "next-step": "_:b2",
-      "previous-step": "_:b0"
-    },
-    "_:b2": {
-      "actions": [
-        {
-          "participants": [],
-          "outputs": [
-            {
-              "type": "reply",
-              "published": "2023-01-23T14:34:42.571948+00:00",
-              "doi": "10.7554/eLife.85111.1.sa1",
-              "url": "https://doi.org/10.7554/eLife.85111.1.sa1",
-              "content": [
-                {
-                  "type": "web-page",
-                  "url": "https://hypothes.is/a/EzFzxJsrEe28DyfQK4aPhg"
-                },
-                {
-                  "type": "web-page",
-                  "url": "https://sciety.org/articles/activity/10.1101/2022.11.08.515698#hypothesis:EzFzxJsrEe28DyfQK4aPhg"
-                },
-                {
-                  "type": "web-page",
-                  "url": "https://sciety.org/evaluations/hypothesis:EzFzxJsrEe28DyfQK4aPhg/content"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "participants": [
-            {
-              "actor": {
-                "name": "anonymous",
-                "type": "person"
-              },
-              "role": "peer-reviewer"
-            }
+      "_:b0": {
+          "actions": [
+              {
+                  "participants": [],
+                  "outputs": [
+                      {
+                          "type": "preprint",
+                          "identifier": "85111",
+                          "doi": "10.7554/eLife.85111.1",
+                          "versionIdentifier": "1",
+                          "license": "http://creativecommons.org/licenses/by/4.0/"
+                      }
+                  ]
+              }
           ],
-          "outputs": [
-            {
-              "type": "review-article",
-              "published": "2023-01-23T14:34:43.676466+00:00",
-              "doi": "10.7554/eLife.85111.1.sa2",
-              "url": "https://doi.org/10.7554/eLife.85111.1.sa2",
-              "content": [
-                {
-                  "type": "web-page",
-                  "url": "https://hypothes.is/a/E9MOvpsrEe2w6nds1t6xxQ"
-                },
-                {
-                  "type": "web-page",
-                  "url": "https://sciety.org/articles/activity/10.1101/2022.11.08.515698#hypothesis:E9MOvpsrEe2w6nds1t6xxQ"
-                },
-                {
-                  "type": "web-page",
-                  "url": "https://sciety.org/evaluations/hypothesis:E9MOvpsrEe2w6nds1t6xxQ/content"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "participants": [
-            {
-              "actor": {
-                "name": "anonymous",
-                "type": "person"
+          "assertions": [
+              {
+                  "item": {
+                      "type": "preprint",
+                      "doi": "10.1101/2022.11.08.515698",
+                      "versionIdentifier": "2"
+                  },
+                  "status": "under-review",
+                  "happened": "2022-11-29T14:20:30+00:00"
               },
-              "role": "peer-reviewer"
-            }
+              {
+                  "item": {
+                      "type": "preprint",
+                      "doi": "10.7554/eLife.85111.1",
+                      "versionIdentifier": "1"
+                  },
+                  "status": "draft"
+              }
           ],
-          "outputs": [
-            {
-              "type": "review-article",
-              "published": "2023-01-23T14:34:44.369019+00:00",
-              "doi": "10.7554/eLife.85111.1.sa3",
-              "url": "https://doi.org/10.7554/eLife.85111.1.sa3",
-              "content": [
-                {
-                  "type": "web-page",
-                  "url": "https://hypothes.is/a/FD5EmpsrEe28RaOWOszMEw"
-                },
-                {
-                  "type": "web-page",
-                  "url": "https://sciety.org/articles/activity/10.1101/2022.11.08.515698#hypothesis:FD5EmpsrEe28RaOWOszMEw"
-                },
-                {
-                  "type": "web-page",
-                  "url": "https://sciety.org/evaluations/hypothesis:FD5EmpsrEe28RaOWOszMEw/content"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "participants": [
-            {
-              "actor": {
-                "name": "Brice Bathellier",
-                "type": "person",
-                "_relatesToOrganization": "CNRS, France"
-              },
-              "role": "editor"
-            },
-            {
-              "actor": {
-                "name": "Kate Wassum",
-                "type": "person",
-                "_relatesToOrganization": "University of California, Los Angeles, United States of America"
-              },
-              "role": "senior-editor"
-            }
+          "inputs": [
+              {
+                  "type": "preprint",
+                  "doi": "10.1101/2022.11.08.515698",
+                  "url": "https://www.biorxiv.org/content/10.1101/2022.11.08.515698v2",
+                  "versionIdentifier": "2",
+                  "published": "2022-11-22",
+                  "content": [
+                      {
+                          "type": "computer-file",
+                          "url": "s3://transfers-elife/biorxiv_Current_Content/November_2022/23_Nov_22_Batch_1444/b0f4d90b-6c92-1014-9a2e-aae015926ab4.meca"
+                      }
+                  ]
+              }
           ],
-          "outputs": [
-            {
-              "type": "evaluation-summary",
-              "published": "2023-01-23T14:34:45.299882+00:00",
-              "doi": "10.7554/eLife.85111.1.sa4",
-              "url": "https://doi.org/10.7554/eLife.85111.1.sa4",
-              "content": [
-                {
-                  "type": "web-page",
-                  "url": "https://hypothes.is/a/FMwbnpsrEe2mVPtbQf2X2w"
-                },
-                {
-                  "type": "web-page",
-                  "url": "https://sciety.org/articles/activity/10.1101/2022.11.08.515698#hypothesis:FMwbnpsrEe2mVPtbQf2X2w"
-                },
-                {
-                  "type": "web-page",
-                  "url": "https://sciety.org/evaluations/hypothesis:FMwbnpsrEe2mVPtbQf2X2w/content"
-                }
-              ]
-            }
-          ]
-        }
-      ],
-      "assertions": [
-        {
-          "item": {
-            "type": "preprint",
-            "doi": "10.1101/2022.11.08.515698",
-            "versionIdentifier": "2"
-          },
-          "status": "peer-reviewed"
-        }
-      ],
-      "inputs": [
-        {
-          "type": "preprint",
-          "doi": "10.1101/2022.11.08.515698",
-          "url": "https://www.biorxiv.org/content/10.1101/2022.11.08.515698v2",
-          "versionIdentifier": "2"
-        }
-      ],
-      "next-step": "_:b3",
-      "previous-step": "_:b1"
-    },
-    "_:b3": {
-      "actions": [
-        {
-          "participants": [],
-          "outputs": [
-            {
-              "type": "preprint",
-              "doi": "10.1101/2022.11.08.515698",
-              "url": "https://www.biorxiv.org/content/10.1101/2022.11.08.515698v3",
-              "published": "2023-03-20",
-              "versionIdentifier": "3",
-              "_tdmPath": "s3://transfers-elife/biorxiv_Current_Content/March_2023/21_Mar_23_Batch_1557/e7c056c2-6c16-1014-98e5-b5f7d8af8b03.meca"
-            }
-          ]
-        }
-      ],
-      "assertions": [
-        {
-          "item": {
-            "type": "preprint",
-            "doi": "10.1101/2022.11.08.515698",
-            "versionIdentifier": "3"
-          },
-          "status": "manuscript-published"
-        }
-      ],
-      "inputs": [],
-      "next-step": "_:b4",
-      "previous-step": "_:b2"
-    },
-    "_:b4": {
-      "actions": [
-        {
-          "participants": [],
-          "outputs": [
-            {
-              "type": "preprint",
-              "identifier": "85111",
-              "versionIdentifier": "2",
-              "doi": "10.7554/eLife.85111.2"
-            }
-          ]
-        },
-        {
-          "participants": [
-            {
-              "actor": {
-                "name": "anonymous",
-                "type": "person"
+          "next-step": "_:b1"
+      },
+      "_:b1": {
+          "actions": [
+              {
+                  "participants": [],
+                  "outputs": [
+                      {
+                          "type": "reply",
+                          "published": "2023-01-23T14:34:42.571948+00:00",
+                          "doi": "10.7554/eLife.85111.1.sa1",
+                          "license": "http://creativecommons.org/licenses/by/4.0/",
+                          "url": "https://doi.org/10.7554/eLife.85111.1.sa1",
+                          "content": [
+                              {
+                                  "type": "web-page",
+                                  "url": "https://hypothes.is/a/EzFzxJsrEe28DyfQK4aPhg"
+                              },
+                              {
+                                  "type": "web-page",
+                                  "url": "https://sciety.org/articles/activity/10.1101/2022.11.08.515698#hypothesis:EzFzxJsrEe28DyfQK4aPhg"
+                              },
+                              {
+                                  "type": "web-page",
+                                  "url": "https://sciety.org/evaluations/hypothesis:EzFzxJsrEe28DyfQK4aPhg/content"
+                              }
+                          ]
+                      }
+                  ]
               },
-              "role": "peer-reviewer"
-            }
+              {
+                  "participants": [
+                      {
+                          "actor": {
+                              "name": "anonymous",
+                              "type": "person"
+                          },
+                          "role": "peer-reviewer"
+                      }
+                  ],
+                  "outputs": [
+                      {
+                          "type": "review-article",
+                          "published": "2023-01-23T14:34:43.676466+00:00",
+                          "doi": "10.7554/eLife.85111.1.sa2",
+                          "license": "http://creativecommons.org/licenses/by/4.0/",
+                          "url": "https://doi.org/10.7554/eLife.85111.1.sa2",
+                          "content": [
+                              {
+                                  "type": "web-page",
+                                  "url": "https://hypothes.is/a/E9MOvpsrEe2w6nds1t6xxQ"
+                              },
+                              {
+                                  "type": "web-page",
+                                  "url": "https://sciety.org/articles/activity/10.1101/2022.11.08.515698#hypothesis:E9MOvpsrEe2w6nds1t6xxQ"
+                              },
+                              {
+                                  "type": "web-page",
+                                  "url": "https://sciety.org/evaluations/hypothesis:E9MOvpsrEe2w6nds1t6xxQ/content"
+                              }
+                          ]
+                      }
+                  ]
+              },
+              {
+                  "participants": [
+                      {
+                          "actor": {
+                              "name": "anonymous",
+                              "type": "person"
+                          },
+                          "role": "peer-reviewer"
+                      }
+                  ],
+                  "outputs": [
+                      {
+                          "type": "review-article",
+                          "published": "2023-01-23T14:34:44.369019+00:00",
+                          "doi": "10.7554/eLife.85111.1.sa3",
+                          "license": "http://creativecommons.org/licenses/by/4.0/",
+                          "url": "https://doi.org/10.7554/eLife.85111.1.sa3",
+                          "content": [
+                              {
+                                  "type": "web-page",
+                                  "url": "https://hypothes.is/a/FD5EmpsrEe28RaOWOszMEw"
+                              },
+                              {
+                                  "type": "web-page",
+                                  "url": "https://sciety.org/articles/activity/10.1101/2022.11.08.515698#hypothesis:FD5EmpsrEe28RaOWOszMEw"
+                              },
+                              {
+                                  "type": "web-page",
+                                  "url": "https://sciety.org/evaluations/hypothesis:FD5EmpsrEe28RaOWOszMEw/content"
+                              }
+                          ]
+                      }
+                  ]
+              },
+              {
+                  "participants": [
+                      {
+                          "actor": {
+                              "name": "Brice Bathellier",
+                              "type": "person",
+                              "_relatesToOrganization": "CNRS, France"
+                          },
+                          "role": "editor"
+                      },
+                      {
+                          "actor": {
+                              "name": "Kate Wassum",
+                              "type": "person",
+                              "_relatesToOrganization": "University of California, Los Angeles, United States of America"
+                          },
+                          "role": "senior-editor"
+                      }
+                  ],
+                  "outputs": [
+                      {
+                          "type": "evaluation-summary",
+                          "published": "2023-01-23T14:34:45.299882+00:00",
+                          "doi": "10.7554/eLife.85111.1.sa4",
+                          "license": "http://creativecommons.org/licenses/by/4.0/",
+                          "url": "https://doi.org/10.7554/eLife.85111.1.sa4",
+                          "content": [
+                              {
+                                  "type": "web-page",
+                                  "url": "https://hypothes.is/a/FMwbnpsrEe2mVPtbQf2X2w"
+                              },
+                              {
+                                  "type": "web-page",
+                                  "url": "https://sciety.org/articles/activity/10.1101/2022.11.08.515698#hypothesis:FMwbnpsrEe2mVPtbQf2X2w"
+                              },
+                              {
+                                  "type": "web-page",
+                                  "url": "https://sciety.org/evaluations/hypothesis:FMwbnpsrEe2mVPtbQf2X2w/content"
+                              }
+                          ]
+                      }
+                  ]
+              }
           ],
-          "outputs": [
-            {
-              "type": "review-article",
-              "published": "2023-04-14T13:42:24.130023+00:00",
-              "doi": "10.7554/eLife.85111.2.sa1",
-              "url": "https://doi.org/10.7554/eLife.85111.2.sa1",
-              "content": [
-                {
-                  "type": "web-page",
-                  "url": "https://hypothes.is/a/L_wlTNrKEe25pKupBGTeqA"
-                },
-                {
-                  "type": "web-page",
-                  "url": "https://sciety.org/articles/activity/10.1101/2022.11.08.515698#hypothesis:L_wlTNrKEe25pKupBGTeqA"
-                },
-                {
-                  "type": "web-page",
-                  "url": "https://sciety.org/evaluations/hypothesis:L_wlTNrKEe25pKupBGTeqA/content"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "participants": [
-            {
-              "actor": {
-                "name": "anonymous",
-                "type": "person"
-              },
-              "role": "peer-reviewer"
-            }
+          "assertions": [
+              {
+                  "item": {
+                      "type": "preprint",
+                      "doi": "10.1101/2022.11.08.515698",
+                      "versionIdentifier": "2"
+                  },
+                  "status": "peer-reviewed"
+              }
           ],
-          "outputs": [
-            {
-              "type": "review-article",
-              "published": "2023-04-14T13:42:24.975810+00:00",
-              "doi": "10.7554/eLife.85111.2.sa2",
-              "url": "https://doi.org/10.7554/eLife.85111.2.sa2",
-              "content": [
-                {
-                  "type": "web-page",
-                  "url": "https://hypothes.is/a/MHuA2trKEe2NmT9GM4xGlw"
-                },
-                {
-                  "type": "web-page",
-                  "url": "https://sciety.org/articles/activity/10.1101/2022.11.08.515698#hypothesis:MHuA2trKEe2NmT9GM4xGlw"
-                },
-                {
-                  "type": "web-page",
-                  "url": "https://sciety.org/evaluations/hypothesis:MHuA2trKEe2NmT9GM4xGlw/content"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "participants": [
-            {
-              "actor": {
-                "name": "Brice Bathellier",
-                "type": "person",
-                "_relatesToOrganization": "CNRS, France"
-              },
-              "role": "editor"
-            },
-            {
-              "actor": {
-                "name": "Kate Wassum",
-                "type": "person",
-                "_relatesToOrganization": "University of California, Los Angeles, United States of America"
-              },
-              "role": "senior-editor"
-            }
+          "inputs": [
+              {
+                  "type": "preprint",
+                  "doi": "10.1101/2022.11.08.515698",
+                  "url": "https://www.biorxiv.org/content/10.1101/2022.11.08.515698v2",
+                  "versionIdentifier": "2"
+              }
           ],
-          "outputs": [
-            {
-              "type": "evaluation-summary",
-              "published": "2023-04-14T13:42:25.781585+00:00",
-              "doi": "10.7554/eLife.85111.2.sa3",
-              "url": "https://doi.org/10.7554/eLife.85111.2.sa3",
-              "content": [
-                {
-                  "type": "web-page",
-                  "url": "https://hypothes.is/a/MPYp6NrKEe2anmsrxlBg-w"
-                },
-                {
-                  "type": "web-page",
-                  "url": "https://sciety.org/articles/activity/10.1101/2022.11.08.515698#hypothesis:MPYp6NrKEe2anmsrxlBg-w"
-                },
-                {
-                  "type": "web-page",
-                  "url": "https://sciety.org/evaluations/hypothesis:MPYp6NrKEe2anmsrxlBg-w/content"
-                }
-              ]
-            }
-          ]
-        }
-      ],
-      "assertions": [
-        {
-          "item": {
-            "type": "preprint",
-            "doi": "10.7554/eLife.85111.2",
-            "versionIdentifier": "2"
-          },
-          "status": "revised"
-        }
-      ],
-      "inputs": [
-        {
-          "type": "preprint",
-          "doi": "10.1101/2022.11.08.515698",
-          "url": "https://www.biorxiv.org/content/10.1101/2022.11.08.515698v3",
-          "versionIdentifier": "3"
-        },
-        {
-          "type": "author-response",
-          "doi": "10.7554/eLife.85111.1.sa1"
-        },
-        {
-          "type": "review-article",
-          "doi": "10.7554/eLife.85111.1.sa2"
-        },
-        {
-          "type": "review-article",
-          "doi": "10.7554/eLife.85111.1.sa3"
-        },
-        {
-          "type": "evaluation-summary",
-          "doi": "10.7554/eLife.85111.1.sa4"
-        }
-      ],
-      "previous-step": "_:b3"
-    }
+          "next-step": "_:b2",
+          "previous-step": "_:b0"
+      },
+      "_:b2": {
+          "actions": [
+              {
+                  "participants": [],
+                  "outputs": [
+                      {
+                          "type": "preprint",
+                          "identifier": "85111",
+                          "doi": "10.7554/eLife.85111.1",
+                          "versionIdentifier": "1",
+                          "license": "http://creativecommons.org/licenses/by/4.0/",
+                          "published": "2023-01-25T14:00:00+00:00"
+                      }
+                  ]
+              }
+          ],
+          "assertions": [
+              {
+                  "item": {
+                      "type": "preprint",
+                      "doi": "10.7554/eLife.85111.1",
+                      "versionIdentifier": "1"
+                  },
+                  "status": "manuscript-published"
+              }
+          ],
+          "inputs": [
+              {
+                  "type": "preprint",
+                  "doi": "10.1101/2022.11.08.515698",
+                  "url": "https://www.biorxiv.org/content/10.1101/2022.11.08.515698v2",
+                  "versionIdentifier": "2"
+              },
+              {
+                  "type": "reply",
+                  "doi": "10.7554/eLife.85111.1.sa1"
+              },
+              {
+                  "type": "review-article",
+                  "doi": "10.7554/eLife.85111.1.sa2"
+              },
+              {
+                  "type": "review-article",
+                  "doi": "10.7554/eLife.85111.1.sa3"
+              },
+              {
+                  "type": "evaluation-summary",
+                  "doi": "10.7554/eLife.85111.1.sa4"
+              }
+          ],
+          "next-step": "_:b3",
+          "previous-step": "_:b1"
+      },
+      "_:b3": {
+          "actions": [
+              {
+                  "participants": [],
+                  "outputs": [
+                      {
+                          "type": "preprint",
+                          "identifier": "85111",
+                          "doi": "10.7554/eLife.85111.2",
+                          "versionIdentifier": "2",
+                          "license": "http://creativecommons.org/licenses/by/4.0/"
+                      }
+                  ]
+              }
+          ],
+          "assertions": [
+              {
+                  "item": {
+                      "type": "preprint",
+                      "doi": "10.1101/2022.11.08.515698",
+                      "versionIdentifier": "3"
+                  },
+                  "status": "under-review",
+                  "happened": "2023-03-23T10:52:45+00:00"
+              },
+              {
+                  "item": {
+                      "type": "preprint",
+                      "doi": "10.7554/eLife.85111.2",
+                      "versionIdentifier": "2"
+                  },
+                  "status": "draft"
+              }
+          ],
+          "inputs": [
+              {
+                  "type": "preprint",
+                  "doi": "10.1101/2022.11.08.515698",
+                  "url": "https://www.biorxiv.org/content/10.1101/2022.11.08.515698v3",
+                  "versionIdentifier": "3",
+                  "published": "2023-03-20",
+                  "content": [
+                      {
+                          "type": "computer-file",
+                          "url": "s3://transfers-elife/biorxiv_Current_Content/March_2023/21_Mar_23_Batch_1557/e7c056c2-6c16-1014-98e5-b5f7d8af8b03.meca"
+                      }
+                  ]
+              }
+          ],
+          "next-step": "_:b4",
+          "previous-step": "_:b2"
+      },
+      "_:b4": {
+          "actions": [
+              {
+                  "participants": [
+                      {
+                          "actor": {
+                              "name": "anonymous",
+                              "type": "person"
+                          },
+                          "role": "peer-reviewer"
+                      }
+                  ],
+                  "outputs": [
+                      {
+                          "type": "review-article",
+                          "published": "2023-04-14T13:42:24.130023+00:00",
+                          "doi": "10.7554/eLife.85111.2.sa1",
+                          "license": "http://creativecommons.org/licenses/by/4.0/",
+                          "url": "https://doi.org/10.7554/eLife.85111.2.sa1",
+                          "content": [
+                              {
+                                  "type": "web-page",
+                                  "url": "https://hypothes.is/a/L_wlTNrKEe25pKupBGTeqA"
+                              },
+                              {
+                                  "type": "web-page",
+                                  "url": "https://sciety.org/articles/activity/10.1101/2022.11.08.515698#hypothesis:L_wlTNrKEe25pKupBGTeqA"
+                              },
+                              {
+                                  "type": "web-page",
+                                  "url": "https://sciety.org/evaluations/hypothesis:L_wlTNrKEe25pKupBGTeqA/content"
+                              }
+                          ]
+                      }
+                  ]
+              },
+              {
+                  "participants": [
+                      {
+                          "actor": {
+                              "name": "anonymous",
+                              "type": "person"
+                          },
+                          "role": "peer-reviewer"
+                      }
+                  ],
+                  "outputs": [
+                      {
+                          "type": "review-article",
+                          "published": "2023-04-14T13:42:24.975810+00:00",
+                          "doi": "10.7554/eLife.85111.2.sa2",
+                          "license": "http://creativecommons.org/licenses/by/4.0/",
+                          "url": "https://doi.org/10.7554/eLife.85111.2.sa2",
+                          "content": [
+                              {
+                                  "type": "web-page",
+                                  "url": "https://hypothes.is/a/MHuA2trKEe2NmT9GM4xGlw"
+                              },
+                              {
+                                  "type": "web-page",
+                                  "url": "https://sciety.org/articles/activity/10.1101/2022.11.08.515698#hypothesis:MHuA2trKEe2NmT9GM4xGlw"
+                              },
+                              {
+                                  "type": "web-page",
+                                  "url": "https://sciety.org/evaluations/hypothesis:MHuA2trKEe2NmT9GM4xGlw/content"
+                              }
+                          ]
+                      }
+                  ]
+              },
+              {
+                  "participants": [
+                      {
+                          "actor": {
+                              "name": "Brice Bathellier",
+                              "type": "person",
+                              "_relatesToOrganization": "CNRS, France"
+                          },
+                          "role": "editor"
+                      },
+                      {
+                          "actor": {
+                              "name": "Kate Wassum",
+                              "type": "person",
+                              "_relatesToOrganization": "University of California, Los Angeles, United States of America"
+                          },
+                          "role": "senior-editor"
+                      }
+                  ],
+                  "outputs": [
+                      {
+                          "type": "evaluation-summary",
+                          "published": "2023-04-14T13:42:25.781585+00:00",
+                          "doi": "10.7554/eLife.85111.2.sa3",
+                          "license": "http://creativecommons.org/licenses/by/4.0/",
+                          "url": "https://doi.org/10.7554/eLife.85111.2.sa3",
+                          "content": [
+                              {
+                                  "type": "web-page",
+                                  "url": "https://hypothes.is/a/MPYp6NrKEe2anmsrxlBg-w"
+                              },
+                              {
+                                  "type": "web-page",
+                                  "url": "https://sciety.org/articles/activity/10.1101/2022.11.08.515698#hypothesis:MPYp6NrKEe2anmsrxlBg-w"
+                              },
+                              {
+                                  "type": "web-page",
+                                  "url": "https://sciety.org/evaluations/hypothesis:MPYp6NrKEe2anmsrxlBg-w/content"
+                              }
+                          ]
+                      }
+                  ]
+              },
+              {
+                  "participants": [],
+                  "outputs": [
+                      {
+                          "type": "reply",
+                          "published": "2023-04-20T09:20:28.046788+00:00",
+                          "doi": "10.7554/eLife.85111.2.sa4",
+                          "license": "http://creativecommons.org/licenses/by/4.0/",
+                          "url": "https://doi.org/10.7554/eLife.85111.2.sa4",
+                          "content": [
+                              {
+                                  "type": "web-page",
+                                  "url": "https://hypothes.is/a/lxpxhN9cEe2uucduJPd1xg"
+                              },
+                              {
+                                  "type": "web-page",
+                                  "url": "https://sciety.org/articles/activity/10.1101/2022.11.08.515698#hypothesis:lxpxhN9cEe2uucduJPd1xg"
+                              },
+                              {
+                                  "type": "web-page",
+                                  "url": "https://sciety.org/evaluations/hypothesis:lxpxhN9cEe2uucduJPd1xg/content"
+                              }
+                          ]
+                      }
+                  ]
+              }
+          ],
+          "assertions": [
+              {
+                  "item": {
+                      "type": "preprint",
+                      "doi": "10.1101/2022.11.08.515698",
+                      "versionIdentifier": "3"
+                  },
+                  "status": "revised"
+              }
+          ],
+          "inputs": [
+              {
+                  "type": "preprint",
+                  "doi": "10.1101/2022.11.08.515698",
+                  "url": "https://www.biorxiv.org/content/10.1101/2022.11.08.515698v3",
+                  "versionIdentifier": "3"
+              }
+          ],
+          "next-step": "_:b5",
+          "previous-step": "_:b3"
+      },
+      "_:b5": {
+          "actions": [
+              {
+                  "participants": [],
+                  "outputs": [
+                      {
+                          "type": "preprint",
+                          "identifier": "85111",
+                          "doi": "10.7554/eLife.85111.2",
+                          "versionIdentifier": "2",
+                          "license": "http://creativecommons.org/licenses/by/4.0/",
+                          "published": "2023-05-10T14:00:00+00:00"
+                      }
+                  ]
+              }
+          ],
+          "assertions": [
+              {
+                  "item": {
+                      "type": "preprint",
+                      "doi": "10.7554/eLife.85111.2",
+                      "versionIdentifier": "2"
+                  },
+                  "status": "manuscript-published"
+              }
+          ],
+          "inputs": [
+              {
+                  "type": "preprint",
+                  "doi": "10.1101/2022.11.08.515698",
+                  "url": "https://www.biorxiv.org/content/10.1101/2022.11.08.515698v3",
+                  "versionIdentifier": "3"
+              },
+              {
+                  "type": "review-article",
+                  "doi": "10.7554/eLife.85111.2.sa1"
+              },
+              {
+                  "type": "review-article",
+                  "doi": "10.7554/eLife.85111.2.sa2"
+              },
+              {
+                  "type": "evaluation-summary",
+                  "doi": "10.7554/eLife.85111.2.sa3"
+              },
+              {
+                  "type": "reply",
+                  "doi": "10.7554/eLife.85111.2.sa4"
+              }
+          ],
+          "previous-step": "_:b4"
+      }
   }
 }

--- a/tests/fixtures/sample_docmap_for_86628.json
+++ b/tests/fixtures/sample_docmap_for_86628.json
@@ -1,424 +1,469 @@
 {
   "@context": "https://w3id.org/docmaps/context.jsonld",
   "type": "docmap",
-  "id": "https://data-hub-api.elifesciences.org/enhanced-preprints/docmaps/v1/by-publisher/elife/get-by-manuscript-id?manuscript_id=86628",
+  "id": "https://data-hub-api.elifesciences.org/enhanced-preprints/docmaps/v2/by-publisher/elife/get-by-manuscript-id?manuscript_id=86628",
   "created": "2023-02-02T07:04:33+00:00",
   "updated": "2023-02-02T07:04:33+00:00",
   "publisher": "{\"account\":{\"id\":\"https://sciety.org/groups/elife\",\"service\":\"https://sciety.org\"},\"homepage\":\"https://elifesciences.org/\",\"id\":\"https://elifesciences.org/\",\"logo\":\"https://sciety.org/static/groups/elife--b560187e-f2fb-4ff9-a861-a204f3fc0fb0.png\",\"name\":\"eLife\"}",
   "first-step": "_:b0",
   "steps": {
-    "_:b0": {
-      "actions": [
-        {
-          "participants": [],
-          "outputs": [
-            {
-              "type": "preprint",
-              "identifier": "86628",
-              "doi": "10.7554/eLife.86628.1",
-              "versionIdentifier": "1",
-              "license": "http://creativecommons.org/licenses/by/4.0/"
-            }
-          ]
-        }
-      ],
-      "assertions": [
-        {
-          "item": {
-            "type": "preprint",
-            "doi": "10.1101/2023.02.14.528498",
-            "versionIdentifier": "2"
-          },
-          "status": "under-review",
-          "happened": "2023-02-14T15:44:21+00:00"
-        },
-        {
-          "item": {
-            "type": "preprint",
-            "doi": "10.7554/eLife.86628.1",
-            "versionIdentifier": "1"
-          },
-          "status": "draft"
-        }
-      ],
-      "inputs": [
-        {
-          "type": "preprint",
-          "doi": "10.1101/2023.02.14.528498",
-          "url": "https://www.biorxiv.org/content/10.1101/2023.02.14.528498v2",
-          "versionIdentifier": "2",
-          "published": "2023-02-21",
-          "_tdmPath": "s3://transfers-elife/biorxiv_Current_Content/February_2023/22_Feb_23_Batch_1531/c27a22b7-6c43-1014-aa80-efc7cf011f1d.meca"
-        }
-      ],
-      "next-step": "_:b1"
-    },
-    "_:b1": {
-      "actions": [
-        {
-          "participants": [
-            {
-              "actor": {
-                "name": "anonymous",
-                "type": "person"
-              },
-              "role": "peer-reviewer"
-            }
+      "_:b0": {
+          "actions": [
+              {
+                  "participants": [],
+                  "outputs": [
+                      {
+                          "type": "preprint",
+                          "identifier": "86628",
+                          "doi": "10.7554/eLife.86628.1",
+                          "versionIdentifier": "1",
+                          "license": "http://creativecommons.org/licenses/by/4.0/"
+                      }
+                  ]
+              }
           ],
-          "outputs": [
-            {
-              "type": "review-article",
-              "published": "2023-04-06T11:44:05.502835+00:00",
-              "doi": "10.7554/eLife.86628.1.sa1",
-              "license": "http://creativecommons.org/licenses/by/4.0/",
-              "url": "https://doi.org/10.7554/eLife.86628.1.sa1",
-              "content": [
-                {
-                  "type": "web-page",
-                  "url": "https://hypothes.is/a/VZA2tNRwEe2Gn6fVyZDsZw"
-                },
-                {
-                  "type": "web-page",
-                  "url": "https://sciety.org/articles/activity/10.1101/2023.02.14.528498#hypothesis:VZA2tNRwEe2Gn6fVyZDsZw"
-                },
-                {
-                  "type": "web-page",
-                  "url": "https://sciety.org/evaluations/hypothesis:VZA2tNRwEe2Gn6fVyZDsZw/content"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "participants": [
-            {
-              "actor": {
-                "name": "Gary Yellen",
-                "type": "person",
-                "_relatesToOrganization": "Harvard Medical School, United States of America"
+          "assertions": [
+              {
+                  "item": {
+                      "type": "preprint",
+                      "doi": "10.1101/2023.02.14.528498",
+                      "versionIdentifier": "2"
+                  },
+                  "status": "under-review",
+                  "happened": "2023-02-14T15:44:21+00:00"
               },
-              "role": "editor"
-            },
-            {
-              "actor": {
-                "name": "David James",
-                "type": "person",
-                "_relatesToOrganization": "University of Sydney, Australia"
-              },
-              "role": "senior-editor"
-            }
+              {
+                  "item": {
+                      "type": "preprint",
+                      "doi": "10.7554/eLife.86628.1",
+                      "versionIdentifier": "1"
+                  },
+                  "status": "draft"
+              }
           ],
-          "outputs": [
-            {
-              "type": "evaluation-summary",
-              "published": "2023-04-06T11:44:15.700445+00:00",
-              "doi": "10.7554/eLife.86628.1.sa2",
-              "license": "http://creativecommons.org/licenses/by/4.0/",
-              "url": "https://doi.org/10.7554/eLife.86628.1.sa2",
-              "content": [
-                {
-                  "type": "web-page",
-                  "url": "https://hypothes.is/a/W6Lk6NRwEe27ZnsdX_tiKQ"
-                },
-                {
-                  "type": "web-page",
-                  "url": "https://sciety.org/articles/activity/10.1101/2023.02.14.528498#hypothesis:W6Lk6NRwEe27ZnsdX_tiKQ"
-                },
-                {
-                  "type": "web-page",
-                  "url": "https://sciety.org/evaluations/hypothesis:W6Lk6NRwEe27ZnsdX_tiKQ/content"
-                }
-              ]
-            }
-          ]
-        }
-      ],
-      "assertions": [
-        {
-          "item": {
-            "type": "preprint",
-            "doi": "10.1101/2023.02.14.528498",
-            "versionIdentifier": "2"
-          },
-          "status": "peer-reviewed"
-        }
-      ],
-      "inputs": [
-        {
-          "type": "preprint",
-          "doi": "10.1101/2023.02.14.528498",
-          "url": "https://www.biorxiv.org/content/10.1101/2023.02.14.528498v2",
-          "versionIdentifier": "2"
-        }
-      ],
-      "next-step": "_:b2",
-      "previous-step": "_:b0"
-    },
-    "_:b2": {
-      "actions": [
-        {
-          "participants": [],
-          "outputs": [
-            {
-              "type": "preprint",
-              "published": "TBC",
-              "identifier": "86628",
-              "doi": "10.7554/eLife.86628.1",
-              "versionIdentifier": "1",
-              "license": "http://creativecommons.org/licenses/by/4.0/"
-            }
-          ]
-        }
-      ],
-      "assertions": [
-        {
-          "item": {
-            "type": "preprint",
-            "doi": "10.7554/eLife.86628.1",
-            "versionIdentifier": "1"
-          },
-          "status": "manuscript-published"
-        }
-      ],
-      "inputs": [
-        {
-          "type": "preprint",
-          "doi": "10.1101/2023.02.14.528498",
-          "url": "https://www.biorxiv.org/content/10.1101/2023.02.14.528498v2",
-          "versionIdentifier": "2"
-        },
-        {
-          "type": "review-article",
-          "doi": "10.7554/eLife.86628.1.sa1"
-        },
-        {
-          "type": "evaluation-summary",
-          "doi": "10.7554/eLife.86628.1.sa2"
-        }],
-      "next-step": "_:b3",
-      "previous-step": "_:b1"
-    },
-    "_:b3": {
-      "actions": [
-        {
-          "participants": [],
-          "outputs": [
-            {
-              "type": "preprint",
-              "identifier": "86628",
-              "doi": "10.7554/eLife.86628.2",
-              "versionIdentifier": "2",
-              "license": "http://creativecommons.org/licenses/by/4.0/"
-            }
-          ]
-        }
-      ],
-      "assertions": [
-        {
-          "item": {
-            "type": "preprint",
-            "doi": "10.1101/2023.02.14.528498",
-            "versionIdentifier": "3"
-          },
-          "status": "under-review",
-          "happened": "2023-04-11T13:15:26+00:00"
-        },
-        {
-          "item": {
-            "type": "preprint",
-            "doi": "10.7554/eLife.86628.2",
-            "versionIdentifier": "2"
-          },
-          "status": "draft"
-        }
-      ],
-      "inputs": [
-        {
-          "type": "preprint",
-          "doi": "10.1101/2023.02.14.528498",
-          "url": "https://www.biorxiv.org/content/10.1101/2023.02.14.528498v3",
-          "versionIdentifier": "3",
-          "published": "2023-04-24",
-          "_tdmPath": ""
-        }
-      ],
-      "next-step": "_:b4",
-      "previous-step": "_:b2"
-    },
-    "_:b4": {
-      "actions": [
-        {
-          "participants": [],
-          "outputs": [
-            {
-              "type": "reply",
-              "published": "2023-05-11T11:34:27.242112+00:00",
-              "doi": "10.7554/eLife.86628.2.sa1",
-              "license": "http://creativecommons.org/licenses/by/4.0/",
-              "url": "https://doi.org/10.7554/eLife.86628.2.sa1",
-              "content": [
-                {
-                  "type": "web-page",
-                  "url": "https://hypothes.is/a/yVioUu_vEe2vQTPxYtnZSw"
-                },
-                {
-                  "type": "web-page",
-                  "url": "https://sciety.org/articles/activity/10.1101/2023.02.14.528498#hypothesis:yVioUu_vEe2vQTPxYtnZSw"
-                },
-                {
-                  "type": "web-page",
-                  "url": "https://sciety.org/evaluations/hypothesis:yVioUu_vEe2vQTPxYtnZSw/content"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "participants": [
-            {
-              "actor": {
-                "name": "anonymous",
-                "type": "person"
-              },
-              "role": "peer-reviewer"
-            }
+          "inputs": [
+              {
+                  "type": "preprint",
+                  "doi": "10.1101/2023.02.14.528498",
+                  "url": "https://www.biorxiv.org/content/10.1101/2023.02.14.528498v2",
+                  "versionIdentifier": "2",
+                  "published": "2023-02-21",
+                  "content": [
+                      {
+                          "type": "computer-file",
+                          "url": "s3://transfers-elife/biorxiv_Current_Content/February_2023/22_Feb_23_Batch_1531/c27a22b7-6c43-1014-aa80-efc7cf011f1d.meca"
+                      }
+                  ]
+              }
           ],
-          "outputs": [
-            {
-              "type": "review-article",
-              "published": "2023-05-11T11:34:28.135284+00:00",
-              "doi": "10.7554/eLife.86628.2.sa2",
-              "license": "http://creativecommons.org/licenses/by/4.0/",
-              "url": "https://doi.org/10.7554/eLife.86628.2.sa2",
-              "content": [
-                {
-                  "type": "web-page",
-                  "url": "https://hypothes.is/a/yeEcZO_vEe2Dxo8DxUJqTw"
-                },
-                {
-                  "type": "web-page",
-                  "url": "https://sciety.org/articles/activity/10.1101/2023.02.14.528498#hypothesis:yeEcZO_vEe2Dxo8DxUJqTw"
-                },
-                {
-                  "type": "web-page",
-                  "url": "https://sciety.org/evaluations/hypothesis:yeEcZO_vEe2Dxo8DxUJqTw/content"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "participants": [
-            {
-              "actor": {
-                "name": "Gary Yellen",
-                "type": "person",
-                "_relatesToOrganization": "Harvard Medical School, United States of America"
+          "next-step": "_:b1"
+      },
+      "_:b1": {
+          "actions": [
+              {
+                  "participants": [
+                      {
+                          "actor": {
+                              "name": "anonymous",
+                              "type": "person"
+                          },
+                          "role": "peer-reviewer"
+                      }
+                  ],
+                  "outputs": [
+                      {
+                          "type": "review-article",
+                          "published": "2023-04-06T11:44:05.502835+00:00",
+                          "doi": "10.7554/eLife.86628.1.sa1",
+                          "license": "http://creativecommons.org/licenses/by/4.0/",
+                          "url": "https://doi.org/10.7554/eLife.86628.1.sa1",
+                          "content": [
+                              {
+                                  "type": "web-page",
+                                  "url": "https://hypothes.is/a/VZA2tNRwEe2Gn6fVyZDsZw"
+                              },
+                              {
+                                  "type": "web-page",
+                                  "url": "https://sciety.org/articles/activity/10.1101/2023.02.14.528498#hypothesis:VZA2tNRwEe2Gn6fVyZDsZw"
+                              },
+                              {
+                                  "type": "web-page",
+                                  "url": "https://sciety.org/evaluations/hypothesis:VZA2tNRwEe2Gn6fVyZDsZw/content"
+                              }
+                          ]
+                      }
+                  ]
               },
-              "role": "editor"
-            },
-            {
-              "actor": {
-                "name": "David James",
-                "type": "person",
-                "_relatesToOrganization": "University of Sydney, Australia"
-              },
-              "role": "senior-editor"
-            }
+              {
+                  "participants": [
+                      {
+                          "actor": {
+                              "name": "Gary Yellen",
+                              "type": "person",
+                              "_relatesToOrganization": "Harvard Medical School, United States of America"
+                          },
+                          "role": "editor"
+                      },
+                      {
+                          "actor": {
+                              "name": "David James",
+                              "type": "person",
+                              "_relatesToOrganization": "University of Sydney, Australia"
+                          },
+                          "role": "senior-editor"
+                      }
+                  ],
+                  "outputs": [
+                      {
+                          "type": "evaluation-summary",
+                          "published": "2023-04-06T11:44:15.700445+00:00",
+                          "doi": "10.7554/eLife.86628.1.sa2",
+                          "license": "http://creativecommons.org/licenses/by/4.0/",
+                          "url": "https://doi.org/10.7554/eLife.86628.1.sa2",
+                          "content": [
+                              {
+                                  "type": "web-page",
+                                  "url": "https://hypothes.is/a/W6Lk6NRwEe27ZnsdX_tiKQ"
+                              },
+                              {
+                                  "type": "web-page",
+                                  "url": "https://sciety.org/articles/activity/10.1101/2023.02.14.528498#hypothesis:W6Lk6NRwEe27ZnsdX_tiKQ"
+                              },
+                              {
+                                  "type": "web-page",
+                                  "url": "https://sciety.org/evaluations/hypothesis:W6Lk6NRwEe27ZnsdX_tiKQ/content"
+                              }
+                          ]
+                      }
+                  ]
+              }
           ],
-          "outputs": [
-            {
-              "type": "evaluation-summary",
-              "published": "2023-05-11T11:34:28.903631+00:00",
-              "doi": "10.7554/eLife.86628.2.sa3",
-              "license": "http://creativecommons.org/licenses/by/4.0/",
-              "url": "https://doi.org/10.7554/eLife.86628.2.sa3",
-              "content": [
-                {
-                  "type": "web-page",
-                  "url": "https://hypothes.is/a/ylaROO_vEe2VSj_o0Xi_gA"
-                },
-                {
-                  "type": "web-page",
-                  "url": "https://sciety.org/articles/activity/10.1101/2023.02.14.528498#hypothesis:ylaROO_vEe2VSj_o0Xi_gA"
-                },
-                {
-                  "type": "web-page",
-                  "url": "https://sciety.org/evaluations/hypothesis:ylaROO_vEe2VSj_o0Xi_gA/content"
-                }
-              ]
-            }
-          ]
-        }
-      ],
-      "assertions": [
-        {
-          "item": {
-            "type": "preprint",
-            "doi": "10.1101/2023.02.14.528498",
-            "versionIdentifier": "3"
-          },
-          "status": "revised"
-        }
-      ],
-      "inputs": [
-        {
-          "type": "preprint",
-          "doi": "10.1101/2023.02.14.528498",
-          "url": "https://www.biorxiv.org/content/10.1101/2023.02.14.528498v3",
-          "versionIdentifier": "3"
-        }
-      ],
-      "next-step": "_:b5",
-      "previous-step": "_:b3"
-    },
-    "_:b5": {
-      "actions": [
-        {
-          "participants": [],
-          "outputs": [
-            {
-              "type": "preprint",
-              "published": "TBC",
-              "identifier": "86628",
-              "doi": "10.7554/eLife.86628.2",
-              "versionIdentifier": "2",
-              "license": "http://creativecommons.org/licenses/by/4.0/"
-            }
-          ]
-        }
-      ],
-      "assertions": [
-        {
-          "item": {
-            "type": "preprint",
-            "doi": "10.7554/eLife.86628.2",
-            "versionIdentifier": "2"
-          },
-          "status": "manuscript-published"
-        }
-      ],
-      "inputs": [
-        {
-          "type": "preprint",
-          "doi": "10.1101/2023.02.14.528498",
-          "url": "https://www.biorxiv.org/content/10.1101/2023.02.14.528498v3",
-          "versionIdentifier": "3"
-        },
-        {
-          "type": "reply",
-          "doi": "10.7554/eLife.86628.2.sa1"
-        },
-        {
-          "type": "review-article",
-          "doi": "10.7554/eLife.86628.2.sa2"
-        },
-        {
-          "type": "evaluation-summary",
-          "doi": "10.7554/eLife.86628.2.sa3"
-        }
-      ],
-      "previous-step": "_:b4"
-    }
+          "assertions": [
+              {
+                  "item": {
+                      "type": "preprint",
+                      "doi": "10.1101/2023.02.14.528498",
+                      "versionIdentifier": "2"
+                  },
+                  "status": "peer-reviewed"
+              }
+          ],
+          "inputs": [
+              {
+                  "type": "preprint",
+                  "doi": "10.1101/2023.02.14.528498",
+                  "url": "https://www.biorxiv.org/content/10.1101/2023.02.14.528498v2",
+                  "versionIdentifier": "2"
+              }
+          ],
+          "next-step": "_:b2",
+          "previous-step": "_:b0"
+      },
+      "_:b2": {
+          "actions": [
+              {
+                  "participants": [],
+                  "outputs": [
+                      {
+                          "type": "preprint",
+                          "identifier": "86628",
+                          "doi": "10.7554/eLife.86628.1",
+                          "versionIdentifier": "1",
+                          "license": "http://creativecommons.org/licenses/by/4.0/",
+                          "published": "2023-04-11T14:00:00+00:00"
+                      }
+                  ]
+              }
+          ],
+          "assertions": [
+              {
+                  "item": {
+                      "type": "preprint",
+                      "doi": "10.7554/eLife.86628.1",
+                      "versionIdentifier": "1"
+                  },
+                  "status": "manuscript-published"
+              }
+          ],
+          "inputs": [
+              {
+                  "type": "preprint",
+                  "doi": "10.1101/2023.02.14.528498",
+                  "url": "https://www.biorxiv.org/content/10.1101/2023.02.14.528498v2",
+                  "versionIdentifier": "2"
+              },
+              {
+                  "type": "review-article",
+                  "doi": "10.7554/eLife.86628.1.sa1"
+              },
+              {
+                  "type": "evaluation-summary",
+                  "doi": "10.7554/eLife.86628.1.sa2"
+              }
+          ],
+          "next-step": "_:b3",
+          "previous-step": "_:b1"
+      },
+      "_:b3": {
+          "actions": [
+              {
+                  "participants": [],
+                  "outputs": [
+                      {
+                          "type": "preprint",
+                          "identifier": "86628",
+                          "doi": "10.7554/eLife.86628.2",
+                          "versionIdentifier": "2",
+                          "license": "http://creativecommons.org/licenses/by/4.0/"
+                      }
+                  ]
+              }
+          ],
+          "assertions": [
+              {
+                  "item": {
+                      "type": "preprint",
+                      "doi": "10.1101/2023.02.14.528498",
+                      "versionIdentifier": "3"
+                  },
+                  "status": "under-review",
+                  "happened": "2023-04-11T13:15:26+00:00"
+              },
+              {
+                  "item": {
+                      "type": "preprint",
+                      "doi": "10.7554/eLife.86628.2",
+                      "versionIdentifier": "2"
+                  },
+                  "status": "draft"
+              }
+          ],
+          "inputs": [
+              {
+                  "type": "preprint",
+                  "doi": "10.1101/2023.02.14.528498",
+                  "url": "https://www.biorxiv.org/content/10.1101/2023.02.14.528498v3",
+                  "versionIdentifier": "3",
+                  "published": "2023-04-24"
+              }
+          ],
+          "next-step": "_:b4",
+          "previous-step": "_:b2"
+      },
+      "_:b4": {
+          "actions": [
+              {
+                  "participants": [],
+                  "outputs": [
+                      {
+                          "type": "reply",
+                          "published": "2023-05-11T11:34:27.242112+00:00",
+                          "doi": "10.7554/eLife.86628.2.sa1",
+                          "license": "http://creativecommons.org/licenses/by/4.0/",
+                          "url": "https://doi.org/10.7554/eLife.86628.2.sa1",
+                          "content": [
+                              {
+                                  "type": "web-page",
+                                  "url": "https://hypothes.is/a/yVioUu_vEe2vQTPxYtnZSw"
+                              },
+                              {
+                                  "type": "web-page",
+                                  "url": "https://sciety.org/articles/activity/10.1101/2023.02.14.528498#hypothesis:yVioUu_vEe2vQTPxYtnZSw"
+                              },
+                              {
+                                  "type": "web-page",
+                                  "url": "https://sciety.org/evaluations/hypothesis:yVioUu_vEe2vQTPxYtnZSw/content"
+                              }
+                          ]
+                      }
+                  ]
+              },
+              {
+                  "participants": [
+                      {
+                          "actor": {
+                              "name": "anonymous",
+                              "type": "person"
+                          },
+                          "role": "peer-reviewer"
+                      }
+                  ],
+                  "outputs": [
+                      {
+                          "type": "review-article",
+                          "published": "2023-05-11T11:34:28.135284+00:00",
+                          "doi": "10.7554/eLife.86628.2.sa2",
+                          "license": "http://creativecommons.org/licenses/by/4.0/",
+                          "url": "https://doi.org/10.7554/eLife.86628.2.sa2",
+                          "content": [
+                              {
+                                  "type": "web-page",
+                                  "url": "https://hypothes.is/a/yeEcZO_vEe2Dxo8DxUJqTw"
+                              },
+                              {
+                                  "type": "web-page",
+                                  "url": "https://sciety.org/articles/activity/10.1101/2023.02.14.528498#hypothesis:yeEcZO_vEe2Dxo8DxUJqTw"
+                              },
+                              {
+                                  "type": "web-page",
+                                  "url": "https://sciety.org/evaluations/hypothesis:yeEcZO_vEe2Dxo8DxUJqTw/content"
+                              }
+                          ]
+                      }
+                  ]
+              },
+              {
+                  "participants": [
+                      {
+                          "actor": {
+                              "name": "Gary Yellen",
+                              "type": "person",
+                              "_relatesToOrganization": "Harvard Medical School, United States of America"
+                          },
+                          "role": "editor"
+                      },
+                      {
+                          "actor": {
+                              "name": "David James",
+                              "type": "person",
+                              "_relatesToOrganization": "University of Sydney, Australia"
+                          },
+                          "role": "senior-editor"
+                      }
+                  ],
+                  "outputs": [
+                      {
+                          "type": "evaluation-summary",
+                          "published": "2023-05-11T11:34:28.903631+00:00",
+                          "doi": "10.7554/eLife.86628.2.sa3",
+                          "license": "http://creativecommons.org/licenses/by/4.0/",
+                          "url": "https://doi.org/10.7554/eLife.86628.2.sa3",
+                          "content": [
+                              {
+                                  "type": "web-page",
+                                  "url": "https://hypothes.is/a/ylaROO_vEe2VSj_o0Xi_gA"
+                              },
+                              {
+                                  "type": "web-page",
+                                  "url": "https://sciety.org/articles/activity/10.1101/2023.02.14.528498#hypothesis:ylaROO_vEe2VSj_o0Xi_gA"
+                              },
+                              {
+                                  "type": "web-page",
+                                  "url": "https://sciety.org/evaluations/hypothesis:ylaROO_vEe2VSj_o0Xi_gA/content"
+                              }
+                          ]
+                      }
+                  ]
+              }
+          ],
+          "assertions": [
+              {
+                  "item": {
+                      "type": "preprint",
+                      "doi": "10.1101/2023.02.14.528498",
+                      "versionIdentifier": "3"
+                  },
+                  "status": "revised"
+              }
+          ],
+          "inputs": [
+              {
+                  "type": "preprint",
+                  "doi": "10.1101/2023.02.14.528498",
+                  "url": "https://www.biorxiv.org/content/10.1101/2023.02.14.528498v3",
+                  "versionIdentifier": "3"
+              }
+          ],
+          "next-step": "_:b5",
+          "previous-step": "_:b3"
+      },
+      "_:b5": {
+          "actions": [
+              {
+                  "participants": [],
+                  "outputs": [
+                      {
+                          "type": "preprint",
+                          "identifier": "86628",
+                          "doi": "10.7554/eLife.86628.2",
+                          "versionIdentifier": "2",
+                          "license": "http://creativecommons.org/licenses/by/4.0/",
+                          "published": "2023-05-15T14:00:00+00:00"
+                      }
+                  ]
+              }
+          ],
+          "assertions": [
+              {
+                  "item": {
+                      "type": "preprint",
+                      "doi": "10.7554/eLife.86628.2",
+                      "versionIdentifier": "2"
+                  },
+                  "status": "manuscript-published"
+              }
+          ],
+          "inputs": [
+              {
+                  "type": "preprint",
+                  "doi": "10.1101/2023.02.14.528498",
+                  "url": "https://www.biorxiv.org/content/10.1101/2023.02.14.528498v3",
+                  "versionIdentifier": "3"
+              },
+              {
+                  "type": "reply",
+                  "doi": "10.7554/eLife.86628.2.sa1"
+              },
+              {
+                  "type": "review-article",
+                  "doi": "10.7554/eLife.86628.2.sa2"
+              },
+              {
+                  "type": "evaluation-summary",
+                  "doi": "10.7554/eLife.86628.2.sa3"
+              }
+          ],
+          "next-step": "_:b6",
+          "previous-step": "_:b4"
+      },
+      "_:b6": {
+          "actions": [
+              {
+                  "participants": [],
+                  "outputs": [
+                      {
+                          "type": "version-of-record",
+                          "doi": "10.7554/eLife.86628.3",
+                          "url": "https://doi.org/10.7554/eLife.86628.3",
+                          "content": [
+                              {
+                                  "type": "web-page",
+                                  "url": "https://elifesciences.org/articles/86628"
+                              }
+                          ]
+                      }
+                  ]
+              }
+          ],
+          "assertions": [
+              {
+                  "item": {
+                      "type": "version-of-record",
+                      "doi": "10.7554/eLife.86628.3",
+                      "versionIdentifier": "3"
+                  },
+                  "status": "vor-published"
+              }
+          ],
+          "inputs": [
+              {
+                  "type": "preprint",
+                  "doi": "10.7554/eLife.86628.2",
+                  "identifier": "86628",
+                  "versionIdentifier": "2"
+              }
+          ],
+          "previous-step": "_:b5"
+      }
   }
 }

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -92,7 +92,7 @@ class TestDocmapSteps85111Sample(unittest.TestCase):
     def test_docmap_steps(self):
         "get the steps of the docmap"
         result = parse.docmap_steps(self.d_json)
-        self.assertEqual(len(result), 5)
+        self.assertEqual(len(result), 6)
 
     def test_docmap_first_step(self):
         "get the first step according to the first-step value"
@@ -107,7 +107,7 @@ class TestDocmapSteps85111Sample(unittest.TestCase):
         "get inputs from the first step"
         first_step = parse.docmap_first_step(self.d_json)
         result = parse.step_inputs(first_step)
-        self.assertEqual(len(result), 0)
+        self.assertEqual(len(result), 1)
         # step _:b1
         step_1 = parse.next_step(self.d_json, first_step)
         result = parse.step_inputs(step_1)
@@ -115,16 +115,20 @@ class TestDocmapSteps85111Sample(unittest.TestCase):
         # step _:b2
         step_2 = parse.next_step(self.d_json, step_1)
         result = parse.step_inputs(step_2)
-        self.assertEqual(len(result), 1)
+        self.assertEqual(len(result), 5)
         # step _:b3
         step_3 = parse.next_step(self.d_json, step_2)
         result = parse.step_inputs(step_3)
-        self.assertEqual(len(result), 0)
+        self.assertEqual(len(result), 1)
         # step _:b4
         step_4 = parse.next_step(self.d_json, step_3)
         result = parse.step_inputs(step_4)
+        self.assertEqual(len(result), 1)
+        # step _:b5
+        step_5 = parse.next_step(self.d_json, step_4)
+        result = parse.step_inputs(step_5)
         self.assertEqual(len(result), 5)
-        self.assertEqual(step_4.get("next-step"), None)
+        self.assertEqual(step_5.get("next-step"), None)
 
     def test_docmap_preprint(self):
         "preprint data from the first step inputs"
@@ -135,9 +139,14 @@ class TestDocmapSteps85111Sample(unittest.TestCase):
                 "type": "preprint",
                 "doi": "10.1101/2022.11.08.515698",
                 "url": "https://www.biorxiv.org/content/10.1101/2022.11.08.515698v2",
-                "published": "2022-11-22",
                 "versionIdentifier": "2",
-                "_tdmPath": "s3://transfers-elife/biorxiv_Current_Content/November_2022/23_Nov_22_Batch_1444/b0f4d90b-6c92-1014-9a2e-aae015926ab4.meca",
+                "published": "2022-11-22",
+                "content": [
+                    {
+                        "type": "computer-file",
+                        "url": "s3://transfers-elife/biorxiv_Current_Content/November_2022/23_Nov_22_Batch_1444/b0f4d90b-6c92-1014-9a2e-aae015926ab4.meca",
+                    }
+                ],
             },
         )
 
@@ -149,41 +158,67 @@ class TestDocmapSteps85111Sample(unittest.TestCase):
             {
                 "type": "preprint",
                 "identifier": "85111",
-                "versionIdentifier": "2",
                 "doi": "10.7554/eLife.85111.2",
+                "versionIdentifier": "2",
+                "license": "http://creativecommons.org/licenses/by/4.0/",
+                "published": "2023-05-10T14:00:00+00:00",
             },
         )
 
     def test_docmap_preprint_history(self):
         "list of preprint history event data for steps with a published date"
         result = parse.docmap_preprint_history(self.d_json)
+        print(result)
         expected = [
             {
                 "type": "preprint",
                 "date": "2022-11-22",
                 "doi": "10.1101/2022.11.08.515698",
                 "url": "https://www.biorxiv.org/content/10.1101/2022.11.08.515698v2",
-                "published": "2022-11-22",
                 "versionIdentifier": "2",
-                "_tdmPath": "s3://transfers-elife/biorxiv_Current_Content/November_2022/23_Nov_22_Batch_1444/b0f4d90b-6c92-1014-9a2e-aae015926ab4.meca",
-            }
+                "published": "2022-11-22",
+                "content": [
+                    {
+                        "type": "computer-file",
+                        "url": "s3://transfers-elife/biorxiv_Current_Content/November_2022/23_Nov_22_Batch_1444/b0f4d90b-6c92-1014-9a2e-aae015926ab4.meca",
+                    }
+                ],
+            },
+            {
+                "type": "reviewed-preprint",
+                "date": "2023-01-25T14:00:00+00:00",
+                "identifier": "85111",
+                "doi": "10.7554/eLife.85111.1",
+                "versionIdentifier": "1",
+                "license": "http://creativecommons.org/licenses/by/4.0/",
+                "published": "2023-01-25T14:00:00+00:00",
+            },
+            {
+                "type": "reviewed-preprint",
+                "date": "2023-05-10T14:00:00+00:00",
+                "identifier": "85111",
+                "doi": "10.7554/eLife.85111.2",
+                "versionIdentifier": "2",
+                "license": "http://creativecommons.org/licenses/by/4.0/",
+                "published": "2023-05-10T14:00:00+00:00",
+            },
         ]
         self.assertEqual(result, expected)
 
     def test_preprint_review_date(self):
         "first preprint under-review date"
         result = parse.preprint_review_date(self.d_json)
-        expected = "2022-11-28T11:30:05+00:00"
+        expected = "2022-11-29T14:20:30+00:00"
         self.assertEqual(result, expected)
 
     def test_step_actions(self):
-        "get actions from the last step"
+        "get actions from the second step"
         step_2 = parse.next_step(
             self.d_json,
             parse.next_step(self.d_json, parse.docmap_first_step(self.d_json)),
         )
         result = parse.step_actions(step_2)
-        self.assertEqual(len(result), 4)
+        self.assertEqual(len(result), 1)
 
     def test_action_outputs(self):
         "outputs from a step action"
@@ -196,9 +231,6 @@ class TestDocmapSteps85111Sample(unittest.TestCase):
         "test parsing docmap JSON into docmap content structure"
         result = parse.docmap_content(self.d_json)
         expected = [
-            OrderedDict(
-                [("type", "preprint"), ("published", None), ("web-content", None)]
-            ),
             OrderedDict(
                 [
                     ("type", "review-article"),
@@ -229,6 +261,16 @@ class TestDocmapSteps85111Sample(unittest.TestCase):
                     ),
                 ]
             ),
+            OrderedDict(
+                [
+                    ("type", "reply"),
+                    ("published", "2023-04-20T09:20:28.046788+00:00"),
+                    (
+                        "web-content",
+                        "https://sciety.org/evaluations/hypothesis:lxpxhN9cEe2uucduJPd1xg/content",
+                    ),
+                ]
+            ),
         ]
         self.assertEqual(result, expected)
 
@@ -241,7 +283,7 @@ class TestDocmapSteps86628Sample(unittest.TestCase):
     def test_docmap_steps(self):
         "get the steps of the docmap"
         result = parse.docmap_steps(self.d_json)
-        self.assertEqual(len(result), 6)
+        self.assertEqual(len(result), 7)
 
     def test_docmap_first_step(self):
         "get the first step according to the first-step value"
@@ -277,7 +319,11 @@ class TestDocmapSteps86628Sample(unittest.TestCase):
         step_5 = parse.next_step(self.d_json, step_4)
         result = parse.step_inputs(step_5)
         self.assertEqual(len(result), 4)
-        self.assertEqual(step_5.get("next-step"), None)
+        # step _:b6
+        step_6 = parse.next_step(self.d_json, step_5)
+        result = parse.step_inputs(step_6)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(step_6.get("next-step"), None)
 
     def test_docmap_preprint(self):
         "preprint data from the first step inputs"
@@ -290,7 +336,12 @@ class TestDocmapSteps86628Sample(unittest.TestCase):
                 "url": "https://www.biorxiv.org/content/10.1101/2023.02.14.528498v2",
                 "versionIdentifier": "2",
                 "published": "2023-02-21",
-                "_tdmPath": "s3://transfers-elife/biorxiv_Current_Content/February_2023/22_Feb_23_Batch_1531/c27a22b7-6c43-1014-aa80-efc7cf011f1d.meca",
+                "content": [
+                    {
+                        "type": "computer-file",
+                        "url": "s3://transfers-elife/biorxiv_Current_Content/February_2023/22_Feb_23_Batch_1531/c27a22b7-6c43-1014-aa80-efc7cf011f1d.meca",
+                    }
+                ],
             },
         )
 
@@ -305,7 +356,7 @@ class TestDocmapSteps86628Sample(unittest.TestCase):
                 "doi": "10.7554/eLife.86628.2",
                 "versionIdentifier": "2",
                 "license": "http://creativecommons.org/licenses/by/4.0/",
-                "published": "TBC",
+                "published": "2023-05-15T14:00:00+00:00",
             },
         )
 
@@ -320,25 +371,30 @@ class TestDocmapSteps86628Sample(unittest.TestCase):
                 "url": "https://www.biorxiv.org/content/10.1101/2023.02.14.528498v2",
                 "versionIdentifier": "2",
                 "published": "2023-02-21",
-                "_tdmPath": "s3://transfers-elife/biorxiv_Current_Content/February_2023/22_Feb_23_Batch_1531/c27a22b7-6c43-1014-aa80-efc7cf011f1d.meca",
+                "content": [
+                    {
+                        "type": "computer-file",
+                        "url": "s3://transfers-elife/biorxiv_Current_Content/February_2023/22_Feb_23_Batch_1531/c27a22b7-6c43-1014-aa80-efc7cf011f1d.meca",
+                    }
+                ],
             },
             {
                 "type": "reviewed-preprint",
-                "date": "TBC",
-                "published": "TBC",
+                "date": "2023-04-11T14:00:00+00:00",
                 "identifier": "86628",
                 "doi": "10.7554/eLife.86628.1",
                 "versionIdentifier": "1",
                 "license": "http://creativecommons.org/licenses/by/4.0/",
+                "published": "2023-04-11T14:00:00+00:00",
             },
             {
                 "type": "reviewed-preprint",
-                "date": "TBC",
-                "published": "TBC",
+                "date": "2023-05-15T14:00:00+00:00",
                 "identifier": "86628",
                 "doi": "10.7554/eLife.86628.2",
                 "versionIdentifier": "2",
                 "license": "http://creativecommons.org/licenses/by/4.0/",
+                "published": "2023-05-15T14:00:00+00:00",
             },
         ]
         self.assertEqual(result, expected)


### PR DESCRIPTION
Only test fixture data and test cases are updated, which now includes more `published` dates, and some different `content`.