### PR TITLE
Fix break_tags() for non-p tag index counting.

### DIFF
--- a/docmaptools/__init__.py
+++ b/docmaptools/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-__version__ = "0.13.0"
+__version__ = "0.14.0"
 
 
 LOGGER = logging.getLogger(__name__)

--- a/docmaptools/convert.py
+++ b/docmaptools/convert.py
@@ -130,30 +130,31 @@ def break_tags(root):
     # find p tag parent to later insert the new p tag
     for p_tag_parent in root.iterfind(".//p/.."):
         # detect break tag as a direct descendant of a p tag
-        for p_index, elem in enumerate(p_tag_parent.iterfind("p")):
-            # find break tags
-            break_tag_indexes = []
-            for tag_index, child_tag in enumerate(elem.iterfind("*")):
-                if child_tag.tag == "break":
-                    break_tag_indexes.append(tag_index)
+        for p_index, elem in enumerate(p_tag_parent.iterfind("*")):
+            if elem.tag == "p":
+                # find break tags
+                break_tag_indexes = []
+                for tag_index, child_tag in enumerate(elem.iterfind("*")):
+                    if child_tag.tag == "break":
+                        break_tag_indexes.append(tag_index)
 
-            # process the list in reverse order so the indexes are reliable
-            break_tag_indexes.reverse()
-            for break_index in break_tag_indexes:
-                p_tag = Element("p")
-                # note: does not retain any text wrapped by a break tag
-                p_tag.text = elem[break_index].tail
+                # process the list in reverse order so the indexes are reliable
+                break_tag_indexes.reverse()
+                for break_index in break_tag_indexes:
+                    p_tag = Element("p")
+                    # note: does not retain any text wrapped by a break tag
+                    p_tag.text = elem[break_index].tail
 
-                for after_break_tag_index, after_break_tag in enumerate(
-                    elem.iterfind("*")
-                ):
-                    if after_break_tag_index > break_index:
-                        p_tag.append(after_break_tag)
-                        elem.remove(after_break_tag)
+                    for after_break_tag_index, after_break_tag in enumerate(
+                        elem.iterfind("*")
+                    ):
+                        if after_break_tag_index > break_index:
+                            p_tag.append(after_break_tag)
+                            elem.remove(after_break_tag)
 
-                elem.remove(elem[break_index])
+                    elem.remove(elem[break_index])
 
-                p_tag_parent.insert(p_index + 1, p_tag)
+                    p_tag_parent.insert(p_index + 1, p_tag)
 
 
 def article_title_tag(root):

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -59,6 +59,32 @@ class TestConvertHtml(unittest.TestCase):
         content = convert.convert_html_string(string)
         self.assertEqual(content, expected)
 
+    def test_br_tag(self):
+        "example of converting br tag to paragraphs"
+        string = (
+            b"<p>We did:</p>"
+            b"<p><strong>Author response image 1.</strong>  <br />"
+            b'<a href="https://imgur.com/Firke60">'
+            b'<img src="https://i.imgur.com/Firke60.jpg" title="source: imgur.com" />'
+            b"</a>"
+            b"</p>"
+            b"<p>The filtration step ....</p>"
+        )
+        expected = (
+            b'<root xmlns:xlink="http://www.w3.org/1999/xlink">'
+            b"<body>"
+            b"<p>We did:</p>"
+            b"<p><bold>Author response image 1.</bold>  </p>"
+            b'<p><ext-link ext-link-type="uri" xlink:href="https://imgur.com/Firke60">'
+            b'<inline-graphic xlink:href="https://i.imgur.com/Firke60.jpg" />'
+            b"</ext-link></p>"
+            b"<p>The filtration step ....</p>"
+            b"</body>"
+            b"</root>"
+        )
+        content = convert.convert_html_string(string)
+        self.assertEqual(content, expected)
+
 
 class TestBreakTags(unittest.TestCase):
     "tests for convert.break_tags()"
@@ -137,6 +163,34 @@ class TestBreakTags(unittest.TestCase):
         "example where the break tag separates an inline formatting open and close tag"
         xml_string = "<root>" "<p>This <italic>is<break/></italic>ugly.</p>" "</root>"
         expected = b"<root><p>This <italic>is<break /></italic>ugly.</p></root>"
+        root = ElementTree.fromstring(xml_string)
+        convert.break_tags(root)
+        self.assertEqual(ElementTree.tostring(root), expected)
+
+    def test_complex_break_tags(self):
+        "many break tags between fig content based on a real example, plus a blockquote tag"
+        xml_string = (
+            "<root>"
+            "<p>First paragraph.</p>"
+            "<blockquote><p>A quotation.</p></blockquote>"
+            "<p><bold>Author response image 1.</bold>  <break />"
+            "This is the caption for this image that describes what it contains.</p>"
+            '<p><img src="elife-70493-inf1.png" /> </p>'
+            "<p><bold>Author response image 2</bold>  <break />"
+            '<img src="elife-70493-inf2.jpg" /></p>'
+            "</root>"
+        )
+        expected = (
+            b"<root>"
+            b"<p>First paragraph.</p>"
+            b"<blockquote><p>A quotation.</p></blockquote>"
+            b"<p><bold>Author response image 1.</bold>  </p>"
+            b"<p>This is the caption for this image that describes what it contains.</p>"
+            b'<p><img src="elife-70493-inf1.png" /> </p>'
+            b"<p><bold>Author response image 2</bold>  </p>"
+            b'<p><img src="elife-70493-inf2.jpg" /></p>'
+            b"</root>"
+        )
         root = ElementTree.fromstring(xml_string)
         convert.break_tags(root)
         self.assertEqual(ElementTree.tostring(root), expected)


### PR DESCRIPTION
Fix to `convert.break_tags()`, when counting tag indexes to figure out where to insert a new `<p>` tag, it was only counting p tags, not all the tags inside the parent tag.

Re issue https://github.com/elifesciences/issues/issues/8435