### PR TITLE
Bug fix to convert.replace_tags() for list-item

### DIFF
--- a/docmaptools/__init__.py
+++ b/docmaptools/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-__version__ = "0.15.0"
+__version__ = "0.16.0"
 
 
 LOGGER = logging.getLogger(__name__)

--- a/docmaptools/convert.py
+++ b/docmaptools/convert.py
@@ -93,7 +93,8 @@ def replace_tags(root):
             for tag_index, child_tag in enumerate(elem.iterfind("*")):
                 # insert into the new tag
                 p_tag.insert(tag_index, child_tag)
-                # remove old tag
+            # remove all old tags from the list-item
+            for child_tag in elem.findall("*"):
                 elem.remove(child_tag)
             # insert the p tag
             elem.insert(0, p_tag)

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -85,6 +85,44 @@ class TestConvertHtml(unittest.TestCase):
         content = convert.convert_html_string(string)
         self.assertEqual(content, expected)
 
+    def test_complicated_list(self):
+        "a more complicated li list with ext-link tags to copy over to the new p tag"
+        string = (
+            b"<ul>"
+            b"<li>"
+            b"In plants, ITPK enzymes catalyze the formation of 5-InsP7 from InP6 "
+            b'<a href="https://pubmed.ncbi.nlm.nih.gov/34274522/">'
+            b"https://pubmed.ncbi.nlm.nih.gov/34274522/"
+            b"</a> "
+            b"and VIH enzymes the formation of 1,5-InsP8 from 5-InsP7 "
+            b'<a href="https://pubmed.ncbi.nlm.nih.gov/25901085/">'
+            b"https://pubmed.ncbi.nlm.nih.gov/25901085/"
+            b"</a>."
+            b"</li>"
+            b"</ul>"
+        )
+        expected = (
+            b'<root xmlns:xlink="http://www.w3.org/1999/xlink">'
+            b"<body>"
+            b'<list list-type="bullet">'
+            b"<list-item>"
+            b"<p>In plants, ITPK enzymes catalyze the formation of 5-InsP7 from InP6 "
+            b'<ext-link ext-link-type="uri" xlink:href="https://pubmed.ncbi.nlm.nih.gov/34274522/">'
+            b"https://pubmed.ncbi.nlm.nih.gov/34274522/"
+            b"</ext-link>"
+            b" and VIH enzymes the formation of 1,5-InsP8 from 5-InsP7 "
+            b'<ext-link ext-link-type="uri" xlink:href="https://pubmed.ncbi.nlm.nih.gov/25901085/">'
+            b"https://pubmed.ncbi.nlm.nih.gov/25901085/"
+            b"</ext-link>."
+            b"</p>"
+            b"</list-item>"
+            b"</list>"
+            b"</body>"
+            b"</root>"
+        )
+        content = convert.convert_html_string(string)
+        self.assertEqual(content, expected)
+
 
 class TestBreakTags(unittest.TestCase):
     "tests for convert.break_tags()"


### PR DESCRIPTION
When replacing `<li>` HTML tags with `<list-item>` XML tags, some content was lost, this is a fix for it.

Re issue https://github.com/elifesciences/issues/issues/8460