### PR TITLE
Optionally get content step for a particular DOI.

### DIFF
--- a/docmaptools/__init__.py
+++ b/docmaptools/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-__version__ = "0.17.0"
+__version__ = "0.18.0"
 
 
 LOGGER = logging.getLogger(__name__)

--- a/docmaptools/parse.py
+++ b/docmaptools/parse.py
@@ -229,7 +229,7 @@ def action_content(action_json):
     return output_content(outputs[0])
 
 
-def content_step(d_json):
+def content_step(d_json, doi=None):
     "find the step which includes peer review content data"
     step = docmap_first_step(d_json)
     step_previous = None
@@ -239,6 +239,8 @@ def content_step(d_json):
             outputs = action_outputs(action)
             for output in outputs:
                 if output.get("type") == "review-article":
+                    if doi and output.get("doi") and output.get("doi").startswith(doi):
+                        return step
                     # remember this step
                     step_previous = step
         # search the next step
@@ -246,11 +248,11 @@ def content_step(d_json):
     return step_previous
 
 
-def docmap_content(d_json):
+def docmap_content(d_json, doi=None):
     "abbreviated and simplified data for content outputs"
     content = []
     # the step from which to get the data
-    step = content_step(d_json)
+    step = content_step(d_json, doi)
     # the actions
     actions = step_actions(step)
     # loop through the outputs

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -1216,6 +1216,26 @@ class TestContentStep(unittest.TestCase):
         d_json = {"first-step": "_:b0", "steps": {"_:b0": content_step}}
         self.assertEqual(parse.content_step(d_json), content_step)
 
+    def test_sample(self):
+        "test a more complete docmap with no doi argument"
+        doi = None
+        expected_previous_step = "_:b3"
+        docmap_string = read_fixture("sample_docmap_for_85111.json", mode="r")
+        d_json = json.loads(docmap_string)
+        self.assertEqual(
+            parse.content_step(d_json, doi).get("previous-step"), expected_previous_step
+        )
+
+    def test_sample_doi(self):
+        "test when doi argument is specified"
+        doi = "10.7554/eLife.85111.1"
+        expected_previous_step = "_:b0"
+        docmap_string = read_fixture("sample_docmap_for_85111.json", mode="r")
+        d_json = json.loads(docmap_string)
+        self.assertEqual(
+            parse.content_step(d_json, doi).get("previous-step"), expected_previous_step
+        )
+
 
 class TestPopulateDocmapContent(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
To find peer review content data for a DOI version previous to the most recent DOI version, pass the DOI value as an argument to find the right steps holding the content for the particular DOI. The argument is optional, so it should be backwards compatible.