### PR TITLE
Support revised status when finding happened date.

### DIFF
--- a/docmaptools/__init__.py
+++ b/docmaptools/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-__version__ = "0.18.0"
+__version__ = "0.19.0"
 
 
 LOGGER = logging.getLogger(__name__)

--- a/docmaptools/parse.py
+++ b/docmaptools/parse.py
@@ -173,7 +173,10 @@ def preprint_assertion_happened_date(step_json, status):
 
 def preprint_happened_date(step_json):
     "happened date from a preprint assertion of status manuscript-published"
-    return preprint_assertion_happened_date(step_json, "manuscript-published")
+    happened = preprint_assertion_happened_date(step_json, "manuscript-published")
+    if not happened:
+        happened = preprint_assertion_happened_date(step_json, "revised")
+    return happened
 
 
 def preprint_review_happened_date(step_json):
@@ -188,10 +191,7 @@ def preprint_alternate_date(step_json):
         return None
     for action_json in step_actions(step_json):
         for output_json in action_outputs(action_json):
-            if (
-                output_json.get("published")
-                and output_json.get("type") == "preprint"
-            ):
+            if output_json.get("published") and output_json.get("type") == "preprint":
                 return output_json.get("published")
     return None
 

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -1143,6 +1143,20 @@ class TestPreprintHappenedDate(unittest.TestCase):
         }
         self.assertEqual(parse.preprint_happened_date(step_json), date_string)
 
+    def test_revised_preprint_happened_date(self):
+        "the data may have revised instead of manuscript-published"
+        date_string = "2023-04-27T15:30:00+00:00"
+        step_json = {
+            "assertions": [
+                {
+                    "status": "revised",
+                    "happened": date_string,
+                    "item": {"type": "preprint"},
+                }
+            ]
+        }
+        self.assertEqual(parse.preprint_happened_date(step_json), date_string)
+
     def test_none(self):
         step_json = None
         self.assertEqual(parse.preprint_happened_date(step_json), None)


### PR DESCRIPTION
Bug fix for when collecting preprint history, newer docmaps have `revised` status in the data for greater than version 1 instead of `manuscript-published`. Look for either one when finding a `happened` date for the preprint version.