### PR TITLE
More precise logic in docmap_latest_preprint()

### DIFF
--- a/docmaptools/__init__.py
+++ b/docmaptools/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-__version__ = "0.19.0"
+__version__ = "0.20.0"
 
 
 LOGGER = logging.getLogger(__name__)

--- a/docmaptools/parse.py
+++ b/docmaptools/parse.py
@@ -67,21 +67,22 @@ def docmap_latest_preprint(d_json):
     "find the most recent preprint in the docmap"
     step = docmap_first_step(d_json)
     most_recent_output = {}
-    if step and step.get("inputs"):
-        # assume the preprint data is the first step first inputs value
-        most_recent_output = step_inputs(step)[0]
-    # continue to search
-    step = next_step(d_json, step)
-    while step:
-        actions = step_actions(step)
-        for action in actions:
-            outputs = action_outputs(action)
-            for output in outputs:
-                if output.get("type") == "preprint":
-                    # remember this value
-                    most_recent_output = output
-        # search the next step
+    if step:
+        if step and step.get("inputs") and len(docmap_steps(d_json)) == 1:
+            # assume the preprint data is the first step first inputs value
+            most_recent_output = step_inputs(step)[0]
+        # continue to search
         step = next_step(d_json, step)
+        while step:
+            actions = step_actions(step)
+            for action in actions:
+                outputs = action_outputs(action)
+                for output in outputs:
+                    if output.get("type") == "preprint":
+                        # remember this value
+                        most_recent_output = output
+            # search the next step
+            step = next_step(d_json, step)
     return most_recent_output
 
 

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -1129,6 +1129,13 @@ class TestPreprintEventOutput(unittest.TestCase):
         self.assertDictEqual(result, expected)
 
 
+class TestDocmapLatestPreprint(unittest.TestCase):
+    def test_docmap_latest_preprint_empty(self):
+        "test for if d_json is empty"
+        result = parse.docmap_latest_preprint({})
+        self.assertEqual(result, {})
+
+
 class TestPreprintHappenedDate(unittest.TestCase):
     def test_preprint_happened_date(self):
         date_string = "2023-04-27T15:30:00+00:00"


### PR DESCRIPTION
The oldest docmap test fixture has only one step and the preprint is in the first step's input. These changes to `parse.docmap_latest_preprint()` is more specific when finding the preprint in the old fixture. Also an improvement to account for when there are no steps.