### PR TITLE
Add published argument to parse.docmap_latest_preprint()

### DIFF
--- a/docmaptools/__init__.py
+++ b/docmaptools/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-__version__ = "0.20.0"
+__version__ = "0.21.0"
 
 
 LOGGER = logging.getLogger(__name__)

--- a/docmaptools/parse.py
+++ b/docmaptools/parse.py
@@ -63,7 +63,7 @@ def docmap_preprint(d_json):
     return {}
 
 
-def docmap_latest_preprint(d_json):
+def docmap_latest_preprint(d_json, published=True):
     "find the most recent preprint in the docmap"
     step = docmap_first_step(d_json)
     most_recent_output = {}
@@ -79,8 +79,12 @@ def docmap_latest_preprint(d_json):
                 outputs = action_outputs(action)
                 for output in outputs:
                     if output.get("type") == "preprint":
-                        # remember this value
-                        most_recent_output = output
+                        if published and output.get("published"):
+                            # remember this value
+                            most_recent_output = output
+                        else:
+                            # remember this value
+                            most_recent_output = output
             # search the next step
             step = next_step(d_json, step)
     return most_recent_output

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -1130,10 +1130,47 @@ class TestPreprintEventOutput(unittest.TestCase):
 
 
 class TestDocmapLatestPreprint(unittest.TestCase):
+    "tests for parse.docmap_latest_preprint()"
+
     def test_docmap_latest_preprint_empty(self):
         "test for if d_json is empty"
         result = parse.docmap_latest_preprint({})
         self.assertEqual(result, {})
+
+    def test_not_published_argument(self):
+        "test returning output which is not published"
+        first_step = {"next-step": "_:b1"}
+        published_step = {
+            "actions": [
+                {
+                    "outputs": [
+                        {
+                            "type": "preprint",
+                            "doi": "10.7554/eLife.95621.1",
+                            "published": "2024-03-27T14:00:00+00:00",
+                        }
+                    ],
+                    "inputs": [{"type": "preprint"}],
+                }
+            ],
+            "next-step": "_:b2",
+        }
+        unpublished_step = {
+            "actions": [
+                {"outputs": [{"type": "preprint", "doi": "10.7554/eLife.95621.2"}]}
+            ]
+        }
+        d_json = {
+            "first-step": "_:b0",
+            "steps": {
+                "_:b0": first_step,
+                "_:b1": published_step,
+                "_:b2": unpublished_step,
+            },
+        }
+        result = parse.docmap_latest_preprint(d_json, published=False)
+        # assert the unpublished outputs data is returned
+        self.assertEqual(result, {"doi": "10.7554/eLife.95621.2", "type": "preprint"})
 
 
 class TestPreprintHappenedDate(unittest.TestCase):


### PR DESCRIPTION
When looking for the outputs of the latest preprint, look for a `published` versions when the `published` function argument is `True`. This avoids returning outputs which are not yet published.

Re issue https://github.com/elifesciences/issues/issues/8694