### PR TITLE
Bug fix docmap_latest_preprint() was returning unpublished DOI values.

### DIFF
--- a/docmaptools/__init__.py
+++ b/docmaptools/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-__version__ = "0.21.0"
+__version__ = "0.21.1"
 
 
 LOGGER = logging.getLogger(__name__)

--- a/docmaptools/parse.py
+++ b/docmaptools/parse.py
@@ -82,7 +82,7 @@ def docmap_latest_preprint(d_json, published=True):
                         if published and output.get("published"):
                             # remember this value
                             most_recent_output = output
-                        else:
+                        elif not published:
                             # remember this value
                             most_recent_output = output
             # search the next step


### PR DESCRIPTION
Bug fix to PR https://github.com/elifesciences/docmap-tools/pull/52, version `0.21.0`

Re issue https://github.com/elifesciences/issues/issues/8729