### PR TITLE
Parse license, volume, elocation-id, article categories.

### DIFF
--- a/docmaptools/__init__.py
+++ b/docmaptools/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-__version__ = "0.22.0"
+__version__ = "0.23.0"
 
 
 LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION
Parse `license` from the output JSON, the others from output JSON `partOf` JSON.

Re issue https://github.com/elifesciences/issues/issues/8586