### PR TITLE
Explicitly match by DOI in parse.content_step()

### DIFF
--- a/docmaptools/__init__.py
+++ b/docmaptools/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-__version__ = "0.23.0"
+__version__ = "0.24.0"
 
 
 LOGGER = logging.getLogger(__name__)

--- a/docmaptools/parse.py
+++ b/docmaptools/parse.py
@@ -266,8 +266,9 @@ def content_step(d_json, doi=None):
                 if output.get("type") == "review-article":
                     if doi and output.get("doi") and output.get("doi").startswith(doi):
                         return step
-                    # remember this step
-                    step_previous = step
+                    elif not doi:
+                        # remember this step
+                        step_previous = step
         # search the next step
         step = next_step(d_json, step)
     return step_previous

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -1690,6 +1690,14 @@ class TestContentStep(unittest.TestCase):
             parse.content_step(d_json, doi).get("previous-step"), expected_previous_step
         )
 
+    def test_doi_not_found(self):
+        "test doi argument does not match any version DOI in the docmap"
+        doi = "foo"
+        expected = None
+        docmap_string = read_fixture("sample_docmap_for_85111.json", mode="r")
+        d_json = json.loads(docmap_string)
+        self.assertEqual(parse.content_step(d_json, doi), expected)
+
 
 class TestPopulateDocmapContent(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Instead of returning the last content step by default, if `doi` argument is specified, only return the step which matches it.