### PR TITLE
Look for additional review types in content_step()

### DIFF
--- a/docmaptools/__init__.py
+++ b/docmaptools/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-__version__ = "0.26.0"
+__version__ = "0.27.0"
 
 
 LOGGER = logging.getLogger(__name__)

--- a/docmaptools/parse.py
+++ b/docmaptools/parse.py
@@ -280,7 +280,11 @@ def content_step(d_json, doi=None):
         for action in actions:
             outputs = action_outputs(action)
             for output in outputs:
-                if output.get("type") == "review-article":
+                if output.get("type") in [
+                    "evaluation-summary",
+                    "reply",
+                    "review-article",
+                ]:
                     if doi and output.get("doi") and output.get("doi").startswith(doi):
                         return step
                     elif not doi:

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -1720,6 +1720,12 @@ class TestContentStep(unittest.TestCase):
         d_json = {"first-step": "_:b0", "steps": {"_:b0": content_step}}
         self.assertEqual(parse.content_step(d_json), content_step)
 
+    def test_reply(self):
+        "test reply type also returns JSON"
+        content_step = {"actions": [{"outputs": [{"type": "reply"}]}]}
+        d_json = {"first-step": "_:b0", "steps": {"_:b0": content_step}}
+        self.assertEqual(parse.content_step(d_json), content_step)
+
     def test_sample(self):
         "test a more complete docmap with no doi argument"
         doi = None


### PR DESCRIPTION
When looking for docmap step content, look for multiple review types instead of only `review-article`.

Re issue https://github.com/elifesciences/issues/issues/9105