### PR TITLE
Fix if url or content is missing from output when parsing.

### DIFF
--- a/docmaptools/__init__.py
+++ b/docmaptools/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-__version__ = "0.27.0"
+__version__ = "0.28.0"
 
 
 LOGGER = logging.getLogger(__name__)

--- a/docmaptools/parse.py
+++ b/docmaptools/parse.py
@@ -252,7 +252,7 @@ def output_content(output_json):
     web_content = [
         content.get("url", {})
         for content in output_json.get("content", [])
-        if content.get("url").endswith("/content")
+        if content and content.get("url") and content.get("url").endswith("/content")
     ]
     # use the first web-content for now
     content_item["web-content"] = web_content[0] if len(web_content) >= 1 else None

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -1154,6 +1154,28 @@ class TestDocmapSteps446694(unittest.TestCase):
         result = parse.output_content(output_json)
         self.assertEqual(result, expected)
 
+    def test_no_url(self):
+        "test if content url is missing"
+        output_json = {
+            "type": "reply",
+            "published": "2022-02-15T11:24:05.730Z",
+            "content": [
+                {
+                    "type": "web-content",
+                }
+            ],
+        }
+        expected = OrderedDict(
+            [
+                ("type", "reply"),
+                ("published", "2022-02-15T11:24:05.730Z"),
+                ("doi", None),
+                ("web-content", None),
+            ]
+        )
+        result = parse.output_content(output_json)
+        self.assertEqual(result, expected)
+
 
 class TestDocmapSteps512253(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Improving the parsing of unusually formatted docmap content, which appears in an edge case test in another project.

Re issue https://github.com/elifesciences/issues/issues/9203